### PR TITLE
Persist queued tasks and verify file existence

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,5 @@ docker run -d --name babelarr \
 ```
 
 The application scans for new `.en.srt` files on startup, upon file creation and every hour thereafter. Translated subtitles are saved beside the source file with language suffixes (e.g. `.nl.srt`, `.bs.srt`).
+
+Queued translation tasks are stored in a small SQLite database (`queue.db` by default) so that pending work survives restarts.


### PR DESCRIPTION
## Summary
- store queued translation tasks in a SQLite-backed persistent queue
- skip tasks whose source file disappeared before processing
- document persistent queue in README

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689e46772280832d845922f8a64134d6