### PR TITLE
Limit LibreTranslate worker threads for stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,5 @@ Queued translation tasks are stored in a small SQLite database (`queue.db` by de
 
 `LOG_LEVEL` controls the verbosity of console output and accepts standard logging levels such as `DEBUG`, `INFO`, `WARNING` and `ERROR`.
 
+`WORKERS` sets the maximum number of concurrent translation threads. Values above 10 are capped to prevent LibreTranslate from becoming unstable due to excessive threading.
+

--- a/main.py
+++ b/main.py
@@ -24,7 +24,15 @@ ROOT_DIRS = [p for p in os.environ.get("WATCH_DIRS", "/data").split(":") if p]
 TARGET_LANGS = os.environ.get("TARGET_LANGS", "nl,bs").split(",")
 SRC_EXT = os.environ.get("SRC_EXT", ".en.srt")
 API_URL = os.environ.get("LIBRETRANSLATE_URL", "http://libretranslate:5000/translate")
-WORKERS = int(os.environ.get("WORKERS", "1"))
+# Limit worker threads to avoid LibreTranslate instability from excessive threads
+# https://github.com/LibreTranslate/LibreTranslate/issues/716 reports crashes after tens of thousands of threads
+MAX_WORKERS = 10
+requested_workers = int(os.environ.get("WORKERS", "1"))
+WORKERS = min(requested_workers, MAX_WORKERS)
+if requested_workers > MAX_WORKERS:
+    logger.warning(
+        "Requested %s workers, capping at %s to prevent instability", requested_workers, MAX_WORKERS
+    )
 QUEUE_DB = os.environ.get("QUEUE_DB", "queue.db")
 logger.debug(
     "Config: ROOT_DIRS=%s TARGET_LANGS=%s SRC_EXT=%s API_URL=%s WORKERS=%s QUEUE_DB=%s",


### PR DESCRIPTION
## Summary
- Cap Babelarr worker threads at 10 to avoid LibreTranslate instability
- Warn when requested worker count exceeds the cap
- Document worker thread limit in README

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689e4c64f108832d8ac16bcbd266ab9a