### PR TITLE
Log detailed HTTP errors from translation

### DIFF
--- a/main.py
+++ b/main.py
@@ -77,7 +77,26 @@ def translate_file(src: Path, lang: str) -> None:
         files = {"file": fh}
         data = {"source": "en", "target": lang, "format": "srt"}
         resp = requests.post(API_URL, files=files, data=data, timeout=60)
-        resp.raise_for_status()
+        try:
+            resp.raise_for_status()
+        except requests.HTTPError:
+            logger.error(
+                "HTTP error %s from LibreTranslate", resp.status_code
+            )
+            logger.error("Headers: %s", resp.headers)
+            logger.error("Body: %s", resp.text)
+            if logger.isEnabledFor(logging.DEBUG):
+                import tempfile
+
+                tmp = tempfile.NamedTemporaryFile(
+                    delete=False, prefix="babelarr-", suffix=".err"
+                )
+                try:
+                    tmp.write(resp.content)
+                    logger.debug("Saved failing response to %s", tmp.name)
+                finally:
+                    tmp.close()
+            raise
     output = src.with_suffix(f".{lang}.srt")
     output.write_bytes(resp.content)
     logger.info("[%s] saved -> %s", lang, output)


### PR DESCRIPTION
## Summary
- add robust HTTPError handling in `translate_file` to log status code, headers, and body
- dump failing responses to a temporary file when running with debug logging

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689e4ff4da34832d969c5cfa868d78a9