### PR TITLE
Persist queue database on mounted volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,16 @@ FROM python:3.11-slim
 
 RUN pip install --no-cache-dir watchdog schedule requests
 
+# Create non-root user (uid/gid 1000)
+RUN groupadd -g 1000 app && useradd -u 1000 -g app -d /app -m app
+
 WORKDIR /app
 COPY main.py .
+
+# Create mount points for subtitles and the persistent queue database
+RUN mkdir -p /data /config && chown -R app:app /data /config /app
+
+USER app:app
 
 # Example environment variables:
 #   -e WATCH_DIRS="/subs:/incoming"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Run the container alongside a LibreTranslate instance:
 docker run -d --name babelarr \
   --network subtitles \
   -v /path/to/subtitles:/data \
+  -v /path/to/config:/config \
   -e WATCH_DIRS="/data" \
   -e TARGET_LANGS="nl,bs" \
   -e LIBRETRANSLATE_URL="http://libretranslate:5000/translate" \
@@ -25,7 +26,10 @@ docker run -d --name babelarr \
 
 The application scans for new `.en.srt` files on startup, upon file creation and every hour thereafter. Translated subtitles are saved beside the source file with language suffixes (e.g. `.nl.srt`, `.bs.srt`).
 
-Queued translation tasks are stored in a small SQLite database (`queue.db` by default) so that pending work survives restarts.
+Queued translation tasks are stored in a small SQLite database (`/config/queue.db` by default) so that pending work survives
+container recreations. Mount the `/config` directory to a persistent location on the host to retain the queue.
+
+The container runs as a non-root user with UID and GID `1000`. Ensure the host paths mounted at `/data` and `/config` are writable by this user.
 
 `LOG_LEVEL` controls the verbosity of console output and accepts standard logging levels such as `DEBUG`, `INFO`, `WARNING` and `ERROR`.
 

--- a/main.py
+++ b/main.py
@@ -52,7 +52,10 @@ if requested_workers > MAX_WORKERS:
     logger.warning(
         "Requested %s workers, capping at %s to prevent instability", requested_workers, MAX_WORKERS
     )
-QUEUE_DB = os.environ.get("QUEUE_DB", "queue.db")
+# Location of the persistent queue database. Default inside /config so it can
+# be mapped to a host directory for persistence across container restarts.
+QUEUE_DB = os.environ.get("QUEUE_DB", "/config/queue.db")
+Path(QUEUE_DB).parent.mkdir(parents=True, exist_ok=True)
 logger.debug(
     "Config: ROOT_DIRS=%s TARGET_LANGS=%s SRC_EXT=%s API_URL=%s WORKERS=%s QUEUE_DB=%s",
     ROOT_DIRS,


### PR DESCRIPTION
## Summary
- store queue database under `/config/queue.db` so it survives container recreation
- create `/data` and `/config` directories for volume mounts
- document new `/config` mount and persistence in README
- run container as non-root user (UID/GID 1000) and document host permissions

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689e55b1b88c832db08f5869410e67fe