### PR TITLE
Use LibreTranslate translate_file endpoint and handle API errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ docker run -d --name babelarr \
   -v /path/to/config:/config \
   -e WATCH_DIRS="/data" \
   -e TARGET_LANGS="nl,bs" \
-  -e LIBRETRANSLATE_URL="http://libretranslate:5000/translate" \
+  -e LIBRETRANSLATE_URL="http://libretranslate:5000/translate_file" \
   -e LOG_LEVEL="INFO" \
   babelarr
 ```


### PR DESCRIPTION
## Summary
- default to the `translate_file` API and log detailed messages for common HTTP error codes
- document new endpoint in README
- test translation error handling across several response codes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e582c6998832d84b56152bf5756ab