### PR TITLE
Refactor into configurable application class

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,186 @@
+import logging
+import queue
+import sqlite3
+import threading
+import time
+from pathlib import Path
+
+import requests
+import schedule
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
+
+from config import Config
+
+logger = logging.getLogger("babelarr")
+
+ERROR_MESSAGES = {
+    400: "Bad Request",
+    403: "Forbidden",
+    404: "Not Found",
+    429: "Too Many Requests",
+    500: "Server Error",
+}
+
+
+class SrtHandler(FileSystemEventHandler):
+    def __init__(self, app: "Application"):
+        self.app = app
+
+    def on_created(self, event):
+        if not event.is_directory:
+            logger.debug("Detected new file %s", event.src_path)
+            self.app.enqueue(Path(event.src_path))
+
+
+class Application:
+    def __init__(self, config: Config):
+        self.config = config
+        self.tasks: queue.Queue[Path] = queue.Queue()
+        self.db_lock = threading.Lock()
+        self.conn = sqlite3.connect(self.config.queue_db, check_same_thread=False)
+        self.conn.execute("CREATE TABLE IF NOT EXISTS queue (path TEXT PRIMARY KEY)")
+        self.conn.commit()
+        self.shutdown_event = threading.Event()
+
+    def translate_file(self, src: Path, lang: str) -> None:
+        logger.debug("Translating %s to %s", src, lang)
+        with open(src, "rb") as fh:
+            files = {"file": fh}
+            data = {"source": "en", "target": lang, "format": "srt"}
+            resp = requests.post(self.config.api_url, files=files, data=data, timeout=60)
+            if resp.status_code != 200:
+                message = ERROR_MESSAGES.get(resp.status_code, "Unexpected error")
+                try:
+                    err_json = resp.json()
+                    detail = err_json.get("error") or err_json.get("message") or err_json.get("detail")
+                    if detail:
+                        message = f"{message}: {detail}"
+                except ValueError:
+                    pass
+                logger.error("HTTP %s from LibreTranslate: %s", resp.status_code, message)
+                logger.error("Headers: %s", resp.headers)
+                logger.error("Body: %s", resp.text)
+                if logger.isEnabledFor(logging.DEBUG):
+                    import tempfile
+
+                    tmp = tempfile.NamedTemporaryFile(delete=False, prefix="babelarr-", suffix=".err")
+                    try:
+                        tmp.write(resp.content)
+                        logger.debug("Saved failing response to %s", tmp.name)
+                    finally:
+                        tmp.close()
+                resp.raise_for_status()
+        output = src.with_suffix(f".{lang}.srt")
+        output.write_bytes(resp.content)
+        logger.info("[%s] saved -> %s", lang, output)
+
+    def worker(self):
+        while not self.shutdown_event.is_set():
+            try:
+                path = self.tasks.get(timeout=1)
+            except queue.Empty:
+                continue
+            logger.debug("Worker picked up %s", path)
+            try:
+                if path.exists():
+                    for lang in self.config.target_langs:
+                        out = path.with_suffix(f".{lang}.srt")
+                        if not out.exists():
+                            logger.info("Translating %s to %s", path, lang)
+                            self.translate_file(path, lang)
+                        else:
+                            logger.debug("Translation already exists: %s", out)
+                else:
+                    logger.warning("missing %s, skipping", path)
+            except Exception as exc:
+                logger.error("translation failed for %s: %s", path, exc)
+                logger.debug("Traceback:", exc_info=True)
+            finally:
+                with self.db_lock:
+                    self.conn.execute("DELETE FROM queue WHERE path = ?", (str(path),))
+                    self.conn.commit()
+                self.tasks.task_done()
+                logger.debug("Finished processing %s", path)
+
+    def needs_translation(self, path: Path) -> bool:
+        for lang in self.config.target_langs:
+            out = path.with_suffix(f".{lang}.srt")
+            if not out.exists():
+                return True
+        return False
+
+    def enqueue(self, path: Path):
+        logger.debug("Attempting to enqueue %s", path)
+        if not str(path).endswith(self.config.src_ext) or not path.is_file():
+            return
+        if not self.needs_translation(path):
+            logger.debug("All translations present for %s; skipping", path)
+            return
+        with self.db_lock:
+            cur = self.conn.execute(
+                "INSERT OR IGNORE INTO queue(path) VALUES (?)", (str(path),)
+            )
+            self.conn.commit()
+        if cur.rowcount:
+            self.tasks.put(path)
+            logger.info("queued %s", path)
+        else:
+            logger.debug("%s already queued", path)
+
+    def full_scan(self):
+        logger.info("Performing full scan")
+        for root in self.config.root_dirs:
+            logger.debug("Scanning %s", root)
+            for file in Path(root).rglob(f"*{self.config.src_ext}"):
+                self.enqueue(file)
+
+    def load_pending(self):
+        logger.info("Loading pending tasks")
+        with self.db_lock:
+            rows = self.conn.execute("SELECT path FROM queue").fetchall()
+        for (p,) in rows:
+            self.tasks.put(Path(p))
+            logger.info("restored %s", p)
+
+    def watch(self):
+        observer = Observer()
+        for root in self.config.root_dirs:
+            logger.debug("Watching %s", root)
+            observer.schedule(SrtHandler(self), root, recursive=True)
+        observer.start()
+        logger.info("Observer started")
+        try:
+            while not self.shutdown_event.is_set():
+                time.sleep(1)
+        finally:
+            observer.stop()
+            observer.join()
+            logger.info("Observer stopped")
+
+    def run(self):
+        logger.info("Starting %d worker threads", self.config.workers)
+        workers = []
+        for _ in range(self.config.workers):
+            t = threading.Thread(target=self.worker)
+            t.start()
+            workers.append(t)
+
+        self.load_pending()
+        self.full_scan()
+        schedule.every().hour.do(self.full_scan)
+
+        watcher = threading.Thread(target=self.watch)
+        watcher.start()
+        logger.info("Service started")
+
+        while not self.shutdown_event.is_set():
+            schedule.run_pending()
+            time.sleep(1)
+
+        logger.info("Shutdown initiated")
+        watcher.join()
+        for t in workers:
+            t.join()
+        self.conn.close()
+        logger.info("Shutdown complete")

--- a/config.py
+++ b/config.py
@@ -1,0 +1,70 @@
+from dataclasses import dataclass
+from pathlib import Path
+import logging
+import os
+
+logger = logging.getLogger("babelarr")
+
+@dataclass
+class Config:
+    root_dirs: list[str]
+    target_langs: list[str]
+    src_ext: str
+    api_url: str
+    workers: int
+    queue_db: str
+
+    @classmethod
+    def from_env(cls) -> "Config":
+        root_dirs = [p for p in os.environ.get("WATCH_DIRS", "/data").split(":") if p]
+
+        raw_langs = os.environ.get("TARGET_LANGS", "nl,bs").split(",")
+        target_langs: list[str] = []
+        seen = set()
+        for lang in raw_langs:
+            cleaned = lang.strip()
+            if not cleaned:
+                logger.warning("Empty language code in TARGET_LANGS; ignoring")
+                continue
+            if not cleaned.isalpha():
+                logger.warning("Invalid language code '%s' in TARGET_LANGS; ignoring", cleaned)
+                continue
+            normalized = cleaned.lower()
+            if normalized in seen:
+                logger.debug("Duplicate language code '%s' in TARGET_LANGS; ignoring", cleaned)
+                continue
+            target_langs.append(normalized)
+            seen.add(normalized)
+
+        src_ext = os.environ.get("SRC_EXT", ".en.srt")
+        api_url = os.environ.get("LIBRETRANSLATE_URL", "http://libretranslate:5000/translate_file")
+
+        MAX_WORKERS = 10
+        requested = int(os.environ.get("WORKERS", "1"))
+        workers = min(requested, MAX_WORKERS)
+        if requested > MAX_WORKERS:
+            logger.warning(
+                "Requested %s workers, capping at %s to prevent instability", requested, MAX_WORKERS
+            )
+
+        queue_db = os.environ.get("QUEUE_DB", "/config/queue.db")
+        Path(queue_db).parent.mkdir(parents=True, exist_ok=True)
+
+        logger.debug(
+            "Config: ROOT_DIRS=%s TARGET_LANGS=%s SRC_EXT=%s API_URL=%s WORKERS=%s QUEUE_DB=%s",
+            root_dirs,
+            target_langs,
+            src_ext,
+            api_url,
+            workers,
+            queue_db,
+        )
+
+        return cls(
+            root_dirs=root_dirs,
+            target_langs=target_langs,
+            src_ext=src_ext,
+            api_url=api_url,
+            workers=workers,
+            queue_db=queue_db,
+        )

--- a/main.py
+++ b/main.py
@@ -1,17 +1,10 @@
 #!/usr/bin/env python3
 import logging
 import os
-import queue
-import sqlite3
-import threading
-import time
-from pathlib import Path
 import signal
 
-import requests
-import schedule
-from watchdog.events import FileSystemEventHandler
-from watchdog.observers import Observer
+from config import Config
+from app import Application
 
 # Logging setup
 logging.basicConfig(
@@ -20,238 +13,19 @@ logging.basicConfig(
 )
 logger = logging.getLogger("babelarr")
 
-# Configuration via environment variables
-ROOT_DIRS = [p for p in os.environ.get("WATCH_DIRS", "/data").split(":") if p]
-# Parse TARGET_LANGS, stripping whitespace, dropping empties, de-duping, and warning
-# on invalid codes
-_raw_langs = os.environ.get("TARGET_LANGS", "nl,bs").split(",")
-TARGET_LANGS = []
-seen_langs = set()
-for lang in _raw_langs:
-    cleaned = lang.strip()
-    if not cleaned:
-        logger.warning("Empty language code in TARGET_LANGS; ignoring")
-        continue
-    if not cleaned.isalpha():
-        logger.warning("Invalid language code '%s' in TARGET_LANGS; ignoring", cleaned)
-        continue
-    normalized = cleaned.lower()
-    if normalized in seen_langs:
-        logger.debug("Duplicate language code '%s' in TARGET_LANGS; ignoring", cleaned)
-        continue
-    TARGET_LANGS.append(normalized)
-    seen_langs.add(normalized)
-SRC_EXT = os.environ.get("SRC_EXT", ".en.srt")
-API_URL = os.environ.get("LIBRETRANSLATE_URL", "http://libretranslate:5000/translate_file")
-# Limit worker threads to avoid LibreTranslate instability from excessive threads
-# https://github.com/LibreTranslate/LibreTranslate/issues/716 reports crashes after tens of thousands of threads
-MAX_WORKERS = 10
-requested_workers = int(os.environ.get("WORKERS", "1"))
-WORKERS = min(requested_workers, MAX_WORKERS)
-if requested_workers > MAX_WORKERS:
-    logger.warning(
-        "Requested %s workers, capping at %s to prevent instability", requested_workers, MAX_WORKERS
-    )
-# Location of the persistent queue database. Default inside /config so it can
-# be mapped to a host directory for persistence across container restarts.
-QUEUE_DB = os.environ.get("QUEUE_DB", "/config/queue.db")
-Path(QUEUE_DB).parent.mkdir(parents=True, exist_ok=True)
-logger.debug(
-    "Config: ROOT_DIRS=%s TARGET_LANGS=%s SRC_EXT=%s API_URL=%s WORKERS=%s QUEUE_DB=%s",
-    ROOT_DIRS,
-    TARGET_LANGS,
-    SRC_EXT,
-    API_URL,
-    WORKERS,
-    QUEUE_DB,
-)
 
-# persistent task queue
-tasks = queue.Queue()
-db_lock = threading.Lock()
-conn = sqlite3.connect(QUEUE_DB, check_same_thread=False)
-conn.execute("CREATE TABLE IF NOT EXISTS queue (path TEXT PRIMARY KEY)")
-conn.commit()
+def main() -> None:
+    config = Config.from_env()
+    app = Application(config)
 
-# Global shutdown event
-shutdown_event = threading.Event()
-
-
-ERROR_MESSAGES = {
-    400: "Bad Request",
-    403: "Forbidden",
-    404: "Not Found",
-    429: "Too Many Requests",
-    500: "Server Error",
-}
-
-
-def translate_file(src: Path, lang: str) -> None:
-    """Send the SRT file to LibreTranslate and store the translated version."""
-    logger.debug("Translating %s to %s", src, lang)
-    with open(src, "rb") as fh:
-        files = {"file": fh}
-        data = {"source": "en", "target": lang, "format": "srt"}
-        resp = requests.post(API_URL, files=files, data=data, timeout=60)
-        if resp.status_code != 200:
-            message = ERROR_MESSAGES.get(resp.status_code, "Unexpected error")
-            try:
-                err_json = resp.json()
-                detail = err_json.get("error") or err_json.get("message") or err_json.get("detail")
-                if detail:
-                    message = f"{message}: {detail}"
-            except ValueError:
-                pass
-            logger.error("HTTP %s from LibreTranslate: %s", resp.status_code, message)
-            logger.error("Headers: %s", resp.headers)
-            logger.error("Body: %s", resp.text)
-            if logger.isEnabledFor(logging.DEBUG):
-                import tempfile
-
-                tmp = tempfile.NamedTemporaryFile(
-                    delete=False, prefix="babelarr-", suffix=".err"
-                )
-                try:
-                    tmp.write(resp.content)
-                    logger.debug("Saved failing response to %s", tmp.name)
-                finally:
-                    tmp.close()
-            resp.raise_for_status()
-    output = src.with_suffix(f".{lang}.srt")
-    output.write_bytes(resp.content)
-    logger.info("[%s] saved -> %s", lang, output)
-
-
-def worker():
-    while not shutdown_event.is_set():
-        try:
-            path = tasks.get(timeout=1)
-        except queue.Empty:
-            continue
-        logger.debug("Worker picked up %s", path)
-        try:
-            if path.exists():
-                for lang in TARGET_LANGS:
-                    out = path.with_suffix(f".{lang}.srt")
-                    if not out.exists():
-                        logger.info("Translating %s to %s", path, lang)
-                        translate_file(path, lang)
-                    else:
-                        logger.debug("Translation already exists: %s", out)
-            else:
-                logger.warning("missing %s, skipping", path)
-        except Exception as exc:
-            logger.error("translation failed for %s: %s", path, exc)
-            logger.debug("Traceback:", exc_info=True)
-        finally:
-            with db_lock:
-                conn.execute("DELETE FROM queue WHERE path = ?", (str(path),))
-                conn.commit()
-            tasks.task_done()
-            logger.debug("Finished processing %s", path)
-
-
-def needs_translation(path: Path) -> bool:
-    """Return True if any target language is missing for the given subtitle."""
-    for lang in TARGET_LANGS:
-        out = path.with_suffix(f".{lang}.srt")
-        if not out.exists():
-            return True
-    return False
-
-
-def enqueue(path: Path):
-    logger.debug("Attempting to enqueue %s", path)
-    if not str(path).endswith(SRC_EXT) or not path.is_file():
-        return
-    if not needs_translation(path):
-        logger.debug("All translations present for %s; skipping", path)
-        return
-    with db_lock:
-        cur = conn.execute(
-            "INSERT OR IGNORE INTO queue(path) VALUES (?)", (str(path),)
-        )
-        conn.commit()
-    if cur.rowcount:
-        tasks.put(path)
-        logger.info("queued %s", path)
-    else:
-        logger.debug("%s already queued", path)
-
-
-def full_scan():
-    logger.info("Performing full scan")
-    for root in ROOT_DIRS:
-        logger.debug("Scanning %s", root)
-        for file in Path(root).rglob(f"*{SRC_EXT}"):
-            enqueue(file)
-
-
-def load_pending():
-    logger.info("Loading pending tasks")
-    with db_lock:
-        rows = conn.execute("SELECT path FROM queue").fetchall()
-    for (p,) in rows:
-        tasks.put(Path(p))
-        logger.info("restored %s", p)
-
-
-class SrtHandler(FileSystemEventHandler):
-    def on_created(self, event):
-        if not event.is_directory:
-            logger.debug("Detected new file %s", event.src_path)
-            enqueue(Path(event.src_path))
-
-
-def watch():
-    observer = Observer()
-    for root in ROOT_DIRS:
-        logger.debug("Watching %s", root)
-        observer.schedule(SrtHandler(), root, recursive=True)
-    observer.start()
-    logger.info("Observer started")
-    try:
-        while not shutdown_event.is_set():
-            time.sleep(1)
-    finally:
-        observer.stop()
-        observer.join()
-        logger.info("Observer stopped")
-
-
-def main():
     def handle_signal(signum, frame):
         logger.info("Received signal %s", signum)
-        shutdown_event.set()
+        app.shutdown_event.set()
 
     for sig in (signal.SIGINT, signal.SIGTERM):
         signal.signal(sig, handle_signal)
 
-    logger.info("Starting %d worker threads", WORKERS)
-    workers = []
-    for _ in range(WORKERS):
-        t = threading.Thread(target=worker)
-        t.start()
-        workers.append(t)
-
-    load_pending()
-    full_scan()
-    schedule.every().hour.do(full_scan)
-
-    watcher = threading.Thread(target=watch)
-    watcher.start()
-    logger.info("Service started")
-
-    while not shutdown_event.is_set():
-        schedule.run_pending()
-        time.sleep(1)
-
-    logger.info("Shutdown initiated")
-    watcher.join()
-    for t in workers:
-        t.join()
-    conn.close()
-    logger.info("Shutdown complete")
+    app.run()
 
 
 if __name__ == "__main__":

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,63 +1,60 @@
-import importlib
 import threading
+
+from app import Application
+from config import Config
+
+
+def make_config(tmp_path, db_path, src_ext):
+    return Config(
+        root_dirs=[str(tmp_path)],
+        target_langs=["nl"],
+        src_ext=src_ext,
+        api_url="http://example",
+        workers=1,
+        queue_db=str(db_path),
+    )
 
 
 def test_enqueue_and_worker(tmp_path, monkeypatch):
-    # Prepare temporary database and subtitle file
     db_path = tmp_path / "queue.db"
     sub_file = tmp_path / "video.en.srt"
     sub_file.write_text("1\n00:00:00,000 --> 00:00:02,000\nHello\n")
 
-    # Set environment for the module under test
-    monkeypatch.setenv("QUEUE_DB", str(db_path))
-    monkeypatch.setenv("TARGET_LANGS", "nl")
-    monkeypatch.setenv("SRC_EXT", ".srt")
+    app = Application(make_config(tmp_path, db_path, ".srt"))
 
-    # Reload module so configuration picks up environment overrides
-    import main
-    importlib.reload(main)
-
-    # Stub out network translation with a simple file write
     def fake_translate_file(src, lang):
         src.with_suffix(f".{lang}.srt").write_text("Hallo")
 
-    monkeypatch.setattr(main, "translate_file", fake_translate_file)
+    monkeypatch.setattr(app, "translate_file", fake_translate_file)
 
-    # Enqueue the sample file and process the queue
-    main.enqueue(sub_file)
-    worker = threading.Thread(target=main.worker)
+    app.enqueue(sub_file)
+    worker = threading.Thread(target=app.worker)
     worker.start()
-    main.tasks.join()
-    main.shutdown_event.set()
+    app.tasks.join()
+    app.shutdown_event.set()
     worker.join(timeout=3)
 
-    # Verify translation saved and task removed from DB
     assert sub_file.with_suffix(".nl.srt").read_text() == "Hallo"
-    with main.db_lock:
-        rows = main.conn.execute("SELECT path FROM queue").fetchall()
+    with app.db_lock:
+        rows = app.conn.execute("SELECT path FROM queue").fetchall()
     assert rows == []
 
-    main.conn.close()
+    app.conn.close()
 
 
-def test_enqueue_skips_when_translated(tmp_path, monkeypatch):
+def test_enqueue_skips_when_translated(tmp_path):
     db_path = tmp_path / "queue.db"
     sub_file = tmp_path / "video.en.srt"
     sub_file.write_text("1\n00:00:00,000 --> 00:00:02,000\nHello\n")
     sub_file.with_suffix(".nl.srt").write_text("Hallo")
 
-    monkeypatch.setenv("QUEUE_DB", str(db_path))
-    monkeypatch.setenv("TARGET_LANGS", "nl")
-    monkeypatch.setenv("SRC_EXT", ".en.srt")
+    app = Application(make_config(tmp_path, db_path, ".en.srt"))
 
-    import main
-    importlib.reload(main)
+    app.enqueue(sub_file)
 
-    main.enqueue(sub_file)
-
-    assert main.tasks.empty()
-    with main.db_lock:
-        rows = main.conn.execute("SELECT path FROM queue").fetchall()
+    assert app.tasks.empty()
+    with app.db_lock:
+        rows = app.conn.execute("SELECT path FROM queue").fetchall()
     assert rows == []
 
-    main.conn.close()
+    app.conn.close()


### PR DESCRIPTION
## Summary
- add Config dataclass for environment-driven configuration
- encapsulate queue, DB, workers, and watcher logic in new Application class
- simplify main to build Config and Application and run the service
- adjust tests to use Application instances with custom configs

## Testing
- `pip install requests watchdog schedule -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ec6e356f0832d9f9f711d489039a9