### PR TITLE
Add queue database repository for thread-safe operations

### DIFF
--- a/queue_db.py
+++ b/queue_db.py
@@ -1,0 +1,90 @@
+"""Queue database repository.
+
+This module provides :class:`QueueRepository` which encapsulates all
+interaction with the SQLite queue database used by the application.  It is
+responsible for creating the connection, ensuring thread safety through a
+lock and exposing a small CRUD style API for manipulating queued paths.
+
+The repository can also be used as a context manager so that connections are
+closed cleanly when leaving a ``with`` block.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from pathlib import Path
+from typing import Iterable, List
+
+
+class QueueRepository:
+    """Simple repository wrapper around the SQLite queue database.
+
+    Parameters
+    ----------
+    db_path:
+        Path to the SQLite database file.
+
+    The repository lazily manages a single connection which is safe to use
+    across multiple threads thanks to an internal :class:`threading.Lock`.
+    """
+
+    def __init__(self, db_path: str):
+        self.db_path = db_path
+        self.lock = threading.Lock()
+        # ``check_same_thread=False`` allows the connection to be shared across
+        # worker threads.  Access is still serialised via ``self.lock``.
+        self.conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        self.conn.execute("CREATE TABLE IF NOT EXISTS queue (path TEXT PRIMARY KEY)")
+        self.conn.commit()
+
+    # ------------------------------------------------------------------
+    # Context manager support
+    # ------------------------------------------------------------------
+    def __enter__(self) -> "QueueRepository":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - trivial
+        self.close()
+
+    def close(self) -> None:
+        """Close the underlying database connection."""
+
+        if getattr(self, "conn", None):
+            self.conn.close()
+            self.conn = None
+
+    # ------------------------------------------------------------------
+    # CRUD operations
+    # ------------------------------------------------------------------
+    def add(self, path: Path) -> bool:
+        """Insert ``path`` into the queue if not already present.
+
+        Returns ``True`` if the path was inserted, ``False`` if it was already
+        queued.
+        """
+
+        with self.lock:
+            cur = self.conn.execute(
+                "INSERT OR IGNORE INTO queue(path) VALUES (?)", (str(path),)
+            )
+            self.conn.commit()
+            return cur.rowcount > 0
+
+    def remove(self, path: Path) -> None:
+        """Remove ``path`` from the queue."""
+
+        with self.lock:
+            self.conn.execute("DELETE FROM queue WHERE path = ?", (str(path),))
+            self.conn.commit()
+
+    def all(self) -> List[Path]:
+        """Return a list of all queued paths."""
+
+        with self.lock:
+            rows = self.conn.execute("SELECT path FROM queue").fetchall()
+        return [Path(p) for (p,) in rows]
+
+
+__all__ = ["QueueRepository"]
+

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -35,11 +35,10 @@ def test_enqueue_and_worker(tmp_path, monkeypatch):
     worker.join(timeout=3)
 
     assert sub_file.with_suffix(".nl.srt").read_text() == "Hallo"
-    with app.db_lock:
-        rows = app.conn.execute("SELECT path FROM queue").fetchall()
+    rows = app.db.all()
     assert rows == []
 
-    app.conn.close()
+    app.db.close()
 
 
 def test_enqueue_skips_when_translated(tmp_path):
@@ -53,8 +52,7 @@ def test_enqueue_skips_when_translated(tmp_path):
     app.enqueue(sub_file)
 
     assert app.tasks.empty()
-    with app.db_lock:
-        rows = app.conn.execute("SELECT path FROM queue").fetchall()
+    rows = app.db.all()
     assert rows == []
 
-    app.conn.close()
+    app.db.close()

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -41,7 +41,7 @@ def test_translate_file(tmp_path, monkeypatch):
     output_file = tmp_file.with_suffix('.nl.srt')
     assert output_file.exists()
     assert output_file.read_bytes() == DummyResponse.content
-    app.conn.close()
+    app.db.close()
 
 
 @pytest.mark.parametrize("status", [400, 403, 404, 429, 500])
@@ -82,4 +82,4 @@ def test_translate_file_errors(tmp_path, monkeypatch, status, caplog):
                 app.translate_file(tmp_file, "nl")
             assert str(status) in caplog.text
     finally:
-        app.conn.close()
+        app.db.close()

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -30,4 +30,4 @@ def test_srt_handler_enqueue(monkeypatch, tmp_path):
     handler.on_created(event)
 
     assert called['path'] == path
-    app.conn.close()
+    app.db.close()


### PR DESCRIPTION
## Summary
- Introduce `QueueRepository` for managing SQLite queue with thread-safe CRUD and context-manager support
- Update `Application` to use the repository instead of direct `conn.execute` calls
- Adjust tests to interact with the repository abstraction

## Testing
- `pytest tests/test_queue.py::test_enqueue_and_worker -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ec97a673c832da73a63cbd7f6efbb