### PR TITLE
Add comprehensive tests and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install -r requirements-dev.txt
+      - run: pytest -q

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,4 @@
 pytest
+requests
+watchdog
+schedule

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,97 @@
+import logging
+import threading
+
+import requests
+
+import app
+from app import Application
+from config import Config
+
+
+def make_config(tmp_path):
+    return Config(
+        root_dirs=[str(tmp_path)],
+        target_langs=["nl"],
+        src_ext=".en.srt",
+        api_url="http://example",
+        workers=1,
+        queue_db=str(tmp_path / "queue.db"),
+    )
+
+
+def test_full_scan(tmp_path, monkeypatch):
+    first = tmp_path / "one.en.srt"
+    first.write_text("a")
+    subdir = tmp_path / "sub"
+    subdir.mkdir()
+    second = subdir / "two.en.srt"
+    second.write_text("b")
+
+    app_instance = Application(make_config(tmp_path))
+    called = []
+    monkeypatch.setattr(app_instance, "enqueue", lambda p: called.append(p))
+
+    app_instance.full_scan()
+
+    assert sorted(called) == sorted([first, second])
+    app_instance.db.close()
+
+
+def test_db_persistence_across_restarts(tmp_path):
+    src = tmp_path / "video.en.srt"
+    src.write_text("hello")
+    config = make_config(tmp_path)
+
+    app1 = Application(config)
+    app1.enqueue(src)
+    app1.db.close()
+
+    app2 = Application(config)
+    app2.load_pending()
+    restored = app2.tasks.get_nowait()
+    assert restored == src
+    app2.db.close()
+
+
+def test_worker_retry_on_network_failure(tmp_path, monkeypatch, caplog):
+    src = tmp_path / "fail.en.srt"
+    src.write_text("hello")
+    config = make_config(tmp_path)
+    app_instance = Application(config)
+
+    attempts = {"count": 0}
+
+    def fake_post(url, files, data, timeout):
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise requests.ConnectionError("boom")
+
+        class Resp:
+            status_code = 200
+            content = b"ok"
+
+            def raise_for_status(self):
+                pass
+
+            headers = {}
+            text = ""
+
+        return Resp()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    worker = threading.Thread(target=app_instance.worker)
+    worker.start()
+
+    with caplog.at_level(logging.ERROR):
+        app_instance.enqueue(src)
+        app_instance.tasks.join()
+        assert any("translation failed" in r.message for r in caplog.records)
+
+    app_instance.enqueue(src)
+    app_instance.tasks.join()
+    app_instance.shutdown_event.set()
+    worker.join()
+
+    assert src.with_suffix(".nl.srt").exists()
+    app_instance.db.close()

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -1,5 +1,6 @@
 from watchdog.events import FileCreatedEvent
 
+import app
 from app import Application, SrtHandler
 from config import Config
 
@@ -31,3 +32,43 @@ def test_srt_handler_enqueue(monkeypatch, tmp_path):
 
     assert called['path'] == path
     app.db.close()
+
+
+def test_watch_lifecycle(monkeypatch, tmp_path):
+    config = Config(
+        root_dirs=[str(tmp_path)],
+        target_langs=["nl"],
+        src_ext=".en.srt",
+        api_url="http://example",
+        workers=1,
+        queue_db=str(tmp_path / "queue.db"),
+    )
+    app_instance = Application(config)
+
+    events = {"start": False, "stop": False, "join": False, "scheduled": []}
+
+    class FakeObserver:
+        def schedule(self, handler, path, recursive):
+            events["scheduled"].append((path, recursive))
+
+        def start(self):
+            events["start"] = True
+
+        def stop(self):
+            events["stop"] = True
+
+        def join(self):
+            events["join"] = True
+
+    monkeypatch.setattr(app, "Observer", FakeObserver)
+
+    def fake_sleep(seconds):
+        app_instance.shutdown_event.set()
+
+    monkeypatch.setattr(app.time, "sleep", fake_sleep)
+
+    app_instance.watch()
+
+    assert events["start"] and events["stop"] and events["join"]
+    assert events["scheduled"] == [(str(tmp_path), True)]
+    app_instance.db.close()


### PR DESCRIPTION
## Summary
- Add tests for full scan, watcher lifecycle, database persistence, and network failure handling
- Configure GitHub Actions to run tests on pull requests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689eca8f1d94832d802989fd90bd1713