### PR TITLE
Refactor translation client abstraction

### DIFF
--- a/babelarr/__init__.py
+++ b/babelarr/__init__.py
@@ -3,5 +3,13 @@
 from .app import Application, SrtHandler
 from .config import Config
 from .queue_db import QueueRepository
+from .translator import LibreTranslateClient, Translator
 
-__all__ = ["Config", "Application", "SrtHandler", "QueueRepository"]
+__all__ = [
+    "Config",
+    "Application",
+    "SrtHandler",
+    "QueueRepository",
+    "Translator",
+    "LibreTranslateClient",
+]

--- a/babelarr/cli.py
+++ b/babelarr/cli.py
@@ -4,6 +4,7 @@ import signal
 
 from .app import Application
 from .config import Config
+from .translator import LibreTranslateClient
 
 logger = logging.getLogger("babelarr")
 
@@ -14,7 +15,8 @@ def main() -> None:
         format="%(asctime)s [%(levelname)s] %(message)s",
     )
     config = Config.from_env()
-    app = Application(config)
+    translator = LibreTranslateClient(config.api_url)
+    app = Application(config, translator)
 
     def handle_signal(signum, frame):
         logger.info("Received signal %s", signum)

--- a/babelarr/translator.py
+++ b/babelarr/translator.py
@@ -1,0 +1,71 @@
+"""Translation client abstractions."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Protocol
+
+import requests
+
+logger = logging.getLogger("babelarr")
+
+ERROR_MESSAGES = {
+    400: "Bad Request",
+    403: "Forbidden",
+    404: "Not Found",
+    429: "Too Many Requests",
+    500: "Server Error",
+}
+
+
+class Translator(Protocol):
+    """Protocol for translation clients."""
+
+    def translate(self, path: Path, lang: str) -> bytes:
+        """Translate the subtitle at *path* to *lang*.
+
+        Returns the translated subtitle bytes or raises an exception.
+        """
+
+
+class LibreTranslateClient:
+    """Translator implementation using the LibreTranslate API."""
+
+    def __init__(self, api_url: str) -> None:
+        self.api_url = api_url
+
+    def translate(self, path: Path, lang: str) -> bytes:
+        with open(path, "rb") as fh:
+            files = {"file": fh}
+            data = {"source": "en", "target": lang, "format": "srt"}
+            resp = requests.post(self.api_url, files=files, data=data, timeout=60)
+        if resp.status_code != 200:
+            message = ERROR_MESSAGES.get(resp.status_code, "Unexpected error")
+            try:
+                err_json = resp.json()
+                detail = (
+                    err_json.get("error")
+                    or err_json.get("message")
+                    or err_json.get("detail")
+                )
+                if detail:
+                    message = f"{message}: {detail}"
+            except ValueError:
+                pass
+            logger.error("HTTP %s from LibreTranslate: %s", resp.status_code, message)
+            logger.error("Headers: %s", resp.headers)
+            logger.error("Body: %s", resp.text)
+            if logger.isEnabledFor(logging.DEBUG):
+                import tempfile
+
+                tmp = tempfile.NamedTemporaryFile(
+                    delete=False, prefix="babelarr-", suffix=".err"
+                )
+                try:
+                    tmp.write(resp.content)
+                    logger.debug("Saved failing response to %s", tmp.name)
+                finally:
+                    tmp.close()
+            resp.raise_for_status()
+        return resp.content

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -4,6 +4,11 @@ from babelarr.app import Application
 from babelarr.config import Config
 
 
+class DummyTranslator:
+    def translate(self, path, lang):
+        return b""
+
+
 def make_config(tmp_path, db_path, src_ext):
     return Config(
         root_dirs=[str(tmp_path)],
@@ -20,7 +25,7 @@ def test_enqueue_and_worker(tmp_path, monkeypatch):
     sub_file = tmp_path / "video.en.srt"
     sub_file.write_text("1\n00:00:00,000 --> 00:00:02,000\nHello\n")
 
-    app = Application(make_config(tmp_path, db_path, ".srt"))
+    app = Application(make_config(tmp_path, db_path, ".srt"), DummyTranslator())
 
     def fake_translate_file(src, lang):
         src.with_suffix(f".{lang}.srt").write_text("Hallo")
@@ -47,7 +52,7 @@ def test_enqueue_skips_when_translated(tmp_path):
     sub_file.write_text("1\n00:00:00,000 --> 00:00:02,000\nHello\n")
     sub_file.with_suffix(".nl.srt").write_text("Hallo")
 
-    app = Application(make_config(tmp_path, db_path, ".en.srt"))
+    app = Application(make_config(tmp_path, db_path, ".en.srt"), DummyTranslator())
 
     app.enqueue(sub_file)
 

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -5,6 +5,11 @@ from babelarr.app import Application, SrtHandler
 from babelarr.config import Config
 
 
+class DummyTranslator:
+    def translate(self, path, lang):
+        return b""
+
+
 def test_srt_handler_enqueue(monkeypatch, tmp_path):
     path = tmp_path / "sample.en.srt"
     path.write_text("example")
@@ -19,7 +24,7 @@ def test_srt_handler_enqueue(monkeypatch, tmp_path):
         workers=1,
         queue_db=str(tmp_path / "queue.db"),
     )
-    app = Application(config)
+    app = Application(config, DummyTranslator())
 
     def fake_enqueue(p):
         called["path"] = p
@@ -43,7 +48,7 @@ def test_watch_lifecycle(monkeypatch, tmp_path):
         workers=1,
         queue_db=str(tmp_path / "queue.db"),
     )
-    app_instance = Application(config)
+    app_instance = Application(config, DummyTranslator())
 
     events = {"start": False, "stop": False, "join": False, "scheduled": []}
 


### PR DESCRIPTION
## Summary
- introduce `Translator` protocol and `LibreTranslateClient`
- inject translator into `Application` and CLI
- update tests to use translator mocks

## Testing
- `pre-commit run --files babelarr/translator.py babelarr/app.py babelarr/cli.py babelarr/__init__.py tests/test_translate.py tests/test_app.py tests/test_queue.py tests/test_watch.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fa255b7a4832d9c595d97cc2bd796