### PR TITLE
Refactor tests to use fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,43 @@
+import pytest
+
+from babelarr.app import Application
+from babelarr.config import Config
+
+
+class _DummyTranslator:
+    def translate(self, path, lang):
+        return b""
+
+
+@pytest.fixture
+def config(tmp_path):
+    return Config(
+        root_dirs=[str(tmp_path)],
+        target_langs=["nl"],
+        src_ext=".en.srt",
+        api_url="http://example",
+        workers=1,
+        queue_db=str(tmp_path / "queue.db"),
+        retry_count=2,
+        backoff_delay=0,
+    )
+
+
+@pytest.fixture
+def app(config):
+    instances = []
+
+    def _create_app(*, translator=None, cfg=None):
+        cfg = cfg or config
+        translator = translator or _DummyTranslator()
+        instance = Application(cfg, translator)
+        instances.append(instance)
+        return instance
+
+    yield _create_app
+
+    for inst in instances:
+        try:
+            inst.db.close()
+        except Exception:
+            pass

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,65 +1,39 @@
 import threading
 
-from babelarr.app import Application
-from babelarr.config import Config
 
-
-class DummyTranslator:
-    def translate(self, path, lang):
-        return b""
-
-
-def make_config(tmp_path, db_path, src_ext):
-    return Config(
-        root_dirs=[str(tmp_path)],
-        target_langs=["nl"],
-        src_ext=src_ext,
-        api_url="http://example",
-        workers=1,
-        queue_db=str(db_path),
-        retry_count=2,
-        backoff_delay=0,
-    )
-
-
-def test_enqueue_and_worker(tmp_path, monkeypatch):
-    db_path = tmp_path / "queue.db"
+def test_enqueue_and_worker(tmp_path, monkeypatch, app, config):
     sub_file = tmp_path / "video.en.srt"
     sub_file.write_text("1\n00:00:00,000 --> 00:00:02,000\nHello\n")
 
-    app = Application(make_config(tmp_path, db_path, ".srt"), DummyTranslator())
+    config.src_ext = ".srt"
+    app_instance = app(cfg=config)
 
     def fake_translate_file(src, lang):
         src.with_suffix(f".{lang}.srt").write_text("Hallo")
 
-    monkeypatch.setattr(app, "translate_file", fake_translate_file)
+    monkeypatch.setattr(app_instance, "translate_file", fake_translate_file)
 
-    app.enqueue(sub_file)
-    worker = threading.Thread(target=app.worker)
+    app_instance.enqueue(sub_file)
+    worker = threading.Thread(target=app_instance.worker)
     worker.start()
-    app.tasks.join()
-    app.shutdown_event.set()
+    app_instance.tasks.join()
+    app_instance.shutdown_event.set()
     worker.join(timeout=3)
 
     assert sub_file.with_suffix(".nl.srt").read_text() == "Hallo"
-    rows = app.db.all()
+    rows = app_instance.db.all()
     assert rows == []
 
-    app.db.close()
 
-
-def test_enqueue_skips_when_translated(tmp_path):
-    db_path = tmp_path / "queue.db"
+def test_enqueue_skips_when_translated(tmp_path, app, config):
     sub_file = tmp_path / "video.en.srt"
     sub_file.write_text("1\n00:00:00,000 --> 00:00:02,000\nHello\n")
     sub_file.with_suffix(".nl.srt").write_text("Hallo")
 
-    app = Application(make_config(tmp_path, db_path, ".en.srt"), DummyTranslator())
+    app_instance = app(cfg=config)
 
-    app.enqueue(sub_file)
+    app_instance.enqueue(sub_file)
 
-    assert app.tasks.empty()
-    rows = app.db.all()
+    assert app_instance.tasks.empty()
+    rows = app_instance.db.all()
     assert rows == []
-
-    app.db.close()


### PR DESCRIPTION
## Summary
- add shared config and app fixtures
- refactor tests to use fixtures and automatically close queue db

## Testing
- `pre-commit run --files tests/conftest.py tests/test_app.py tests/test_queue.py tests/test_translate.py tests/test_watch.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fb17a7fe8832d8e4f9624d618208b