### PR TITLE
Refactor LibreTranslate URL handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,12 @@ docker run -d --name babelarr \
   -v /path/to/config:/config \
   -e WATCH_DIRS="/data" \
   -e TARGET_LANGS="nl,bs" \
-  -e LIBRETRANSLATE_URL="http://libretranslate:5000/translate_file" \
+  -e LIBRETRANSLATE_URL="http://libretranslate:5000" \
   -e LOG_LEVEL="INFO" \
   babelarr
 ```
+
+`LIBRETRANSLATE_URL` should include only the protocol, hostname or IP, and port of your LibreTranslate instance. The `translate_file` API path is appended automatically.
 
 The application scans for new `.en.srt` files on startup, upon file creation and every hour thereafter. Translated subtitles are saved beside the source file with language suffixes (e.g. `.nl.srt`, `.bs.srt`).
 

--- a/babelarr/config.py
+++ b/babelarr/config.py
@@ -44,9 +44,7 @@ class Config:
             seen.add(normalized)
 
         src_ext = os.environ.get("SRC_EXT", ".en.srt")
-        api_url = os.environ.get(
-            "LIBRETRANSLATE_URL", "http://libretranslate:5000/translate_file"
-        )
+        api_url = os.environ.get("LIBRETRANSLATE_URL", "http://libretranslate:5000")
 
         MAX_WORKERS = 10
         requested = int(os.environ.get("WORKERS", "1"))

--- a/babelarr/translator.py
+++ b/babelarr/translator.py
@@ -36,7 +36,7 @@ class LibreTranslateClient:
     def __init__(
         self, api_url: str, retry_count: int = 3, backoff_delay: float = 1.0
     ) -> None:
-        self.api_url = api_url
+        self.api_url = api_url.rstrip("/") + "/translate_file"
         self.retry_count = retry_count
         self.backoff_delay = backoff_delay
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       WATCH_DIRS: "/data"
       TARGET_LANGS: "nl,bs"
       SRC_EXT: ".en.srt"
-      LIBRETRANSLATE_URL: "http://libretranslate:5000/translate_file"
+      LIBRETRANSLATE_URL: "http://libretranslate:5000"
       LOG_LEVEL: "INFO"
       WORKERS: "1"
       QUEUE_DB: "/config/queue.db"


### PR DESCRIPTION
## Summary
- Remove `/translate_file` path from `LIBRETRANSLATE_URL` configuration
- Automatically append API path when creating LibreTranslate client
- Clarify documentation and docker-compose example to use base URL only

## Testing
- `pre-commit run --files babelarr/config.py babelarr/translator.py README.md docker-compose.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fb4863434832da3e468fd917a9c47