### PR TITLE
Ensure Docker image installs dependencies and copies project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY pyproject.toml ./
 COPY babelarr ./babelarr
 RUN pip install --no-cache-dir .
 
+COPY . .
 # Create mount points for subtitles and the persistent queue database
 RUN mkdir -p /data /config && chown -R app:app /data /config /app
 
@@ -16,4 +17,4 @@ USER app:app
 # Example environment variables:
 #   -e WATCH_DIRS="/subs:/incoming"
 #   -e TARGET_LANGS="nl,bs"
-CMD ["babelarr"]
+ENTRYPOINT ["babelarr"]


### PR DESCRIPTION
## Summary
- Install Python dependencies then copy entire project into image
- Configure container to run `babelarr` via ENTRYPOINT

## Testing
- `pytest`
- `docker build -t babelarr:test .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_689fb6707d7c832da4fc83cd06f7dce7