### PR TITLE
Handle subtitle updates and debounce file writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ docker run -d --name babelarr \
 
 The application scans for new `.en.srt` files on startup, upon file creation and every hour thereafter. Translated subtitles are saved beside the source file with language suffixes (e.g. `.nl.srt`, `.bs.srt`).
 
+Existing subtitles that are modified or moved are re-queued for translation after a short debounce to ensure the file is fully written.
+
 Queued translation tasks are stored in a small SQLite database (`/config/queue.db` by default) so that pending work survives
 container recreations. Mount the `/config` directory to a persistent location on the host to retain the queue.
 
@@ -36,6 +38,8 @@ The container runs as a non-root user with UID and GID `1000`. Ensure the host p
 `LOG_LEVEL` controls the verbosity of console output and accepts standard logging levels such as `DEBUG`, `INFO`, `WARNING` and `ERROR`.
 
 `WORKERS` sets the maximum number of concurrent translation threads. Values above 10 are capped to prevent LibreTranslate from becoming unstable due to excessive threading.
+
+`DEBOUNCE_SECONDS` configures the delay used to verify that a file has finished writing before it is queued. Increase this value if subtitle files are large or written slowly.
 
 
 ## Testing

--- a/babelarr/config.py
+++ b/babelarr/config.py
@@ -8,6 +8,20 @@ logger = logging.getLogger("babelarr")
 
 @dataclass
 class Config:
+    """Application configuration.
+
+    Attributes:
+        root_dirs: Directories to watch for subtitle files.
+        target_langs: Languages to translate into.
+        src_ext: Source subtitle file extension.
+        api_url: Base URL of the translation API.
+        workers: Number of translation worker threads.
+        queue_db: Path to the SQLite queue database.
+        retry_count: Translation retry attempts.
+        backoff_delay: Initial backoff delay between retries.
+        debounce: Seconds to wait for file changes to settle before enqueueing.
+    """
+
     root_dirs: list[str]
     target_langs: list[str]
     src_ext: str
@@ -16,6 +30,7 @@ class Config:
     queue_db: str
     retry_count: int = 3
     backoff_delay: float = 1.0
+    debounce: float = 0.1
 
     @classmethod
     def from_env(cls) -> "Config":
@@ -61,10 +76,11 @@ class Config:
 
         retry_count = int(os.environ.get("RETRY_COUNT", "3"))
         backoff_delay = float(os.environ.get("BACKOFF_DELAY", "1"))
+        debounce = float(os.environ.get("DEBOUNCE_SECONDS", "0.1"))
 
         logger.debug(
             "Config: ROOT_DIRS=%s TARGET_LANGS=%s SRC_EXT=%s API_URL=%s "
-            "WORKERS=%s QUEUE_DB=%s RETRY_COUNT=%s BACKOFF_DELAY=%s",
+            "WORKERS=%s QUEUE_DB=%s RETRY_COUNT=%s BACKOFF_DELAY=%s DEBOUNCE=%s",
             root_dirs,
             target_langs,
             src_ext,
@@ -73,6 +89,7 @@ class Config:
             queue_db,
             retry_count,
             backoff_delay,
+            debounce,
         )
 
         return cls(
@@ -84,4 +101,5 @@ class Config:
             queue_db=queue_db,
             retry_count=retry_count,
             backoff_delay=backoff_delay,
+            debounce=debounce,
         )


### PR DESCRIPTION
## Summary
- Requeue subtitles when files are created, modified, or moved
- Wait for file writes to settle before enqueueing
- Document configurable debounce interval via `DEBOUNCE_SECONDS`

## Testing
- `pre-commit run --files README.md babelarr/app.py babelarr/config.py tests/test_watch.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fbce76124832da92fde5f5602928b