### PR TITLE
Use session for translator requests

### DIFF
--- a/babelarr/app.py
+++ b/babelarr/app.py
@@ -176,4 +176,7 @@ class Application:
         watcher.join()
         executor.shutdown(wait=True)
         self.db.close()
+        close = getattr(self.translator, "close", None)
+        if callable(close):
+            close()
         logger.info("Shutdown complete")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,9 @@ class _DummyTranslator:
     def translate(self, path, lang):
         return b""
 
+    def close(self):
+        pass
+
 
 @pytest.fixture
 def config(tmp_path):
@@ -41,3 +44,6 @@ def app(config):
             inst.db.close()
         except Exception:
             pass
+        close = getattr(inst.translator, "close", None)
+        if callable(close):
+            close()


### PR DESCRIPTION
## Summary
- manage LibreTranslate connections with a persistent `requests.Session`
- add `close()` to Translator and close session during Application shutdown
- update tests to mock session posts and clean up clients

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fbfecff44832dbb0785a5a4f6a541