### PR TITLE
Skip non-existent directories in watcher

### DIFF
--- a/babelarr/app.py
+++ b/babelarr/app.py
@@ -149,6 +149,10 @@ class Application:
         observer = Observer()
         for root in self.config.root_dirs:
             logger.debug("Watching %s", root)
+            root_path = Path(root)
+            if not root_path.exists():
+                logger.warning("Directory %s does not exist; skipping", root_path)
+                continue
             observer.schedule(SrtHandler(self), root, recursive=True)
         observer.start()
         logger.info("Observer started")


### PR DESCRIPTION
## Summary
- avoid scheduling watchdog observers for directories that don't exist
- add test verifying watcher logs and skips missing paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a030a2f398832da2805a699c947911