### PR TITLE
Handle uppercase subtitle extensions

### DIFF
--- a/babelarr/app.py
+++ b/babelarr/app.py
@@ -121,7 +121,9 @@ class Application:
 
     def enqueue(self, path: Path):
         logger.debug("Attempting to enqueue %s", path)
-        if not str(path).endswith(self.config.src_ext) or not path.is_file():
+        if not path.is_file() or not path.name.lower().endswith(
+            self.config.src_ext.lower()
+        ):
             return
         if not self.needs_translation(path):
             logger.debug("All translations present for %s; skipping", path)


### PR DESCRIPTION
## Summary
- ensure `Application.enqueue` matches subtitle extensions case-insensitively
- add a regression test for files with uppercase subtitle extensions

## Testing
- `pre-commit run --files babelarr/app.py tests/test_queue.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a031dc23fc832dbc36cb35f2bde0f9