### PR TITLE
Streamline source language and queue DB configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Babelarr
 
-A lightweight subtitle translator that watches directories for `.en.srt` files and uses [LibreTranslate](https://libretranslate.com/) to generate translations such as Dutch and Bosnian. Files are discovered through a watchdog and periodic scans, queued, and translated sequentially.
+A lightweight subtitle translator that watches directories for subtitle files in a configurable source language (default `.en.srt`) and uses [LibreTranslate](https://libretranslate.com/) to generate translations such as Dutch and Bosnian. Files are discovered through a watchdog and periodic scans, queued, and translated sequentially.
 
 ## Usage and Installation
 
@@ -18,27 +18,34 @@ docker run -d --name babelarr \
   -v /path/to/subtitles:/data \
   -v /path/to/config:/config \
   -e WATCH_DIRS="/data" \
+  -e SRC_LANG="en" \
   -e TARGET_LANGS="nl,bs" \
   -e LIBRETRANSLATE_URL="http://libretranslate:5000" \
   -e LOG_LEVEL="INFO" \
   babelarr
 ```
 
+### Environment variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `WATCH_DIRS` | `/data` | Colon-separated directories to scan for subtitles. |
+| `TARGET_LANGS` | `nl,bs` | Comma-separated language codes to translate into. |
+| `SRC_LANG` | `en` | Two-letter source language of existing subtitles; files matching `*.LANG.srt` are processed. |
+| `LIBRETRANSLATE_URL` | `http://libretranslate:5000` | Base URL of the LibreTranslate instance (no path). |
+| `LOG_LEVEL` | `INFO` | Controls verbosity of console output. |
+| `WORKERS` | `1` | Number of translation worker threads (maximum 10). |
+| `RETRY_COUNT` | `3` | Translation retry attempts. |
+| `BACKOFF_DELAY` | `1` | Initial delay between retries in seconds. |
+| `DEBOUNCE_SECONDS` | `0.1` | Wait time to ensure files have finished writing before enqueueing. |
+
 `LIBRETRANSLATE_URL` should include only the protocol, hostname or IP, and port of your LibreTranslate instance. The `translate_file` API path is appended automatically.
 
-The application scans for new `.en.srt` files on startup, upon file creation and every hour thereafter. Translated subtitles are saved beside the source file with language suffixes (e.g. `.nl.srt`, `.bs.srt`).
+Queued translation tasks are stored in a small SQLite database (`/config/queue.db`) so that pending work survives container recreations. Mount the `/config` directory to a persistent location on the host to retain the queue.
 
-Existing subtitles that are modified or moved are re-queued for translation after a short debounce to ensure the file is fully written.
-
-Queued translation tasks are stored in a small SQLite database (`/config/queue.db` by default) so that pending work survives container recreations. Mount the `/config` directory to a persistent location on the host to retain the queue.
+The application scans for new source-language subtitles on startup, upon file creation and every hour thereafter. Translated subtitles are saved beside the source file with language suffixes (e.g. `.nl.srt`, `.bs.srt`). Existing subtitles that are modified or moved are re-queued for translation after a short debounce to ensure the file is fully written.
 
 The container runs as a non-root user with UID and GID `1000`. Ensure the host paths mounted at `/data` and `/config` are writable by this user.
-
-`LOG_LEVEL` controls the verbosity of console output and accepts standard logging levels such as `DEBUG`, `INFO`, `WARNING` and `ERROR`.
-
-`WORKERS` sets the maximum number of concurrent translation threads. Values above 10 are capped to prevent LibreTranslate from becoming unstable due to excessive threading.
-
-`DEBOUNCE_SECONDS` configures the delay used to verify that a file has finished writing before it is queued. Increase this value if subtitle files are large or written slowly.
 
 Example `docker-compose.yml`:
 
@@ -63,6 +70,7 @@ services:
       - ./config:/config
     environment:
       WATCH_DIRS: "/data"
+      SRC_LANG: "en"
       TARGET_LANGS: "nl,bs"
       LIBRETRANSLATE_URL: "http://libretranslate:5000"
 ```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ def config(tmp_path):
     return Config(
         root_dirs=[str(tmp_path)],
         target_langs=["nl"],
+        src_lang="en",
         src_ext=".en.srt",
         api_url="http://example",
         workers=1,

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -173,6 +173,7 @@ def test_watch_missing_directory(monkeypatch, tmp_path, app, caplog):
     cfg = app_module.Config(
         root_dirs=[str(existing), str(missing)],
         target_langs=["nl"],
+        src_lang="en",
         src_ext=".en.srt",
         api_url="http://example",
         workers=1,


### PR DESCRIPTION
## Summary
- Replace `SRC_EXT` with two-letter `SRC_LANG` environment variable for source subtitles
- Fix queue database path to `/config/queue.db` and drop `QUEUE_DB` override
- Document configuration variables in a new README table and update usage examples

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a047b3cd78832db0e5cd8b31348f85