### PR TITLE
Validate startup directories and translation service

### DIFF
--- a/babelarr/cli.py
+++ b/babelarr/cli.py
@@ -1,6 +1,9 @@
 import logging
 import os
 import signal
+from pathlib import Path
+
+import requests
 
 from .app import Application
 from .config import Config
@@ -9,12 +12,48 @@ from .translator import LibreTranslateClient
 logger = logging.getLogger("babelarr")
 
 
+def validate_environment(config: Config) -> None:
+    """Validate watch directories and translation service availability.
+
+    Updates ``config.root_dirs`` to only include readable directories. If none
+    remain, the process exits with a clear error. The translation service is
+    checked with a simple ``HEAD`` request and the process aborts if it is
+    unreachable.
+    """
+
+    valid_dirs: list[str] = []
+    for d in config.root_dirs:
+        path = Path(d)
+        if not path.is_dir():
+            logger.warning("Watch directory %s does not exist; ignoring", d)
+            continue
+        if not os.access(path, os.R_OK):
+            logger.warning("Watch directory %s is not readable; ignoring", d)
+            continue
+        valid_dirs.append(d)
+
+    if not valid_dirs:
+        logger.error("No readable watch directories found: %s", config.root_dirs)
+        raise SystemExit("No valid watch directories configured")
+
+    config.root_dirs = valid_dirs
+
+    try:
+        resp = requests.head(config.api_url, timeout=5)
+        if resp.status_code >= 400:
+            raise requests.RequestException(f"HTTP {resp.status_code}")
+    except requests.RequestException as exc:
+        logger.error("Translation service %s unreachable: %s", config.api_url, exc)
+        raise SystemExit(f"Translation service unreachable: {config.api_url}")
+
+
 def main() -> None:
     logging.basicConfig(
         level=os.environ.get("LOG_LEVEL", "INFO").upper(),
         format="%(asctime)s [%(levelname)s] %(message)s",
     )
     config = Config.from_env()
+    validate_environment(config)
     translator = LibreTranslateClient(
         config.api_url, config.retry_count, config.backoff_delay
     )


### PR DESCRIPTION
## Summary
- ensure watch directories are readable and exit if none are valid
- check translation API availability during startup
- add tests for invalid watch dirs and unreachable API

## Testing
- `pre-commit run --files babelarr/cli.py tests/test_app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a059bca64c832dad770d3447c82662