### PR TITLE
Add optional API key for LibreTranslate

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ docker run -d --name babelarr \
 | `TARGET_LANGS` | `nl,bs` | Comma-separated language codes to translate into. |
 | `SRC_LANG` | `en` | Two-letter source language of existing subtitles; files matching `*.LANG.srt` are processed. |
 | `LIBRETRANSLATE_URL` | `http://libretranslate:5000` | Base URL of the LibreTranslate instance (no path). |
+| `LIBRETRANSLATE_API_KEY` | *(unset)* | API key for authenticated LibreTranslate instances. |
 | `LOG_LEVEL` | `INFO` | Controls verbosity of console output. |
 | `WORKERS` | `1` | Number of translation worker threads (maximum 10). |
 | `RETRY_COUNT` | `3` | Translation retry attempts. |

--- a/babelarr/cli.py
+++ b/babelarr/cli.py
@@ -55,7 +55,10 @@ def main() -> None:
     config = Config.from_env()
     validate_environment(config)
     translator = LibreTranslateClient(
-        config.api_url, config.retry_count, config.backoff_delay
+        config.api_url,
+        config.retry_count,
+        config.backoff_delay,
+        api_key=config.api_key,
     )
     app = Application(config, translator)
 

--- a/babelarr/config.py
+++ b/babelarr/config.py
@@ -18,6 +18,7 @@ class Config:
         api_url: Base URL of the translation API.
         workers: Number of translation worker threads.
         queue_db: Path to the SQLite queue database.
+        api_key: Optional API key for authenticated requests.
         retry_count: Translation retry attempts.
         backoff_delay: Initial backoff delay between retries.
         debounce: Seconds to wait for file changes to settle before enqueueing.
@@ -30,6 +31,7 @@ class Config:
     api_url: str
     workers: int
     queue_db: str
+    api_key: str | None = None
     retry_count: int = 3
     backoff_delay: float = 1.0
     debounce: float = 0.1
@@ -80,19 +82,22 @@ class Config:
         queue_db = "/config/queue.db"
         Path(queue_db).parent.mkdir(parents=True, exist_ok=True)
 
+        api_key = os.environ.get("LIBRETRANSLATE_API_KEY") or None
         retry_count = int(os.environ.get("RETRY_COUNT", "3"))
         backoff_delay = float(os.environ.get("BACKOFF_DELAY", "1"))
         debounce = float(os.environ.get("DEBOUNCE_SECONDS", "0.1"))
 
         logger.debug(
             "Config: ROOT_DIRS=%s TARGET_LANGS=%s SRC_LANG=%s API_URL=%s "
-            "WORKERS=%s QUEUE_DB=%s RETRY_COUNT=%s BACKOFF_DELAY=%s DEBOUNCE=%s",
+            "WORKERS=%s QUEUE_DB=%s API_KEY_SET=%s RETRY_COUNT=%s "
+            "BACKOFF_DELAY=%s DEBOUNCE=%s",
             root_dirs,
             target_langs,
             src_lang,
             api_url,
             workers,
             queue_db,
+            bool(api_key),
             retry_count,
             backoff_delay,
             debounce,
@@ -106,6 +111,7 @@ class Config:
             api_url=api_url,
             workers=workers,
             queue_db=queue_db,
+            api_key=api_key,
             retry_count=retry_count,
             backoff_delay=backoff_delay,
             debounce=debounce,

--- a/babelarr/translator.py
+++ b/babelarr/translator.py
@@ -37,11 +37,16 @@ class LibreTranslateClient:
     """Translator implementation using the LibreTranslate API."""
 
     def __init__(
-        self, api_url: str, retry_count: int = 3, backoff_delay: float = 1.0
+        self,
+        api_url: str,
+        retry_count: int = 3,
+        backoff_delay: float = 1.0,
+        api_key: str | None = None,
     ) -> None:
         self.api_url = api_url.rstrip("/") + "/translate_file"
         self.retry_count = retry_count
         self.backoff_delay = backoff_delay
+        self.api_key = api_key
         self.session = requests.Session()
 
     def translate(self, path: Path, lang: str) -> bytes:
@@ -52,6 +57,8 @@ class LibreTranslateClient:
                 with open(path, "rb") as fh:
                     files = {"file": fh}
                     data = {"source": "en", "target": lang, "format": "srt"}
+                    if self.api_key:
+                        data["api_key"] = self.api_key
                     resp = self.session.post(
                         self.api_url, files=files, data=data, timeout=60
                     )


### PR DESCRIPTION
## Summary
- allow Config to read `LIBRETRANSLATE_API_KEY`
- send API key with LibreTranslate requests when provided
- document `LIBRETRANSLATE_API_KEY` env var and test authenticated requests

## Testing
- `pre-commit run --files babelarr/config.py babelarr/translator.py babelarr/cli.py README.md tests/test_translate.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a05c599f7c832db09e01090b8ca4fa