### PR TITLE
Add configurable source language to translation client

### DIFF
--- a/babelarr/cli.py
+++ b/babelarr/cli.py
@@ -56,6 +56,7 @@ def main() -> None:
     validate_environment(config)
     translator = LibreTranslateClient(
         config.api_url,
+        config.src_lang,
         config.retry_count,
         config.backoff_delay,
         api_key=config.api_key,

--- a/babelarr/translator.py
+++ b/babelarr/translator.py
@@ -39,11 +39,13 @@ class LibreTranslateClient:
     def __init__(
         self,
         api_url: str,
+        src_lang: str,
         retry_count: int = 3,
         backoff_delay: float = 1.0,
         api_key: str | None = None,
     ) -> None:
         self.api_url = api_url.rstrip("/") + "/translate_file"
+        self.src_lang = src_lang
         self.retry_count = retry_count
         self.backoff_delay = backoff_delay
         self.api_key = api_key
@@ -56,7 +58,7 @@ class LibreTranslateClient:
             try:
                 with open(path, "rb") as fh:
                     files = {"file": fh}
-                    data = {"source": "en", "target": lang, "format": "srt"}
+                    data = {"source": self.src_lang, "target": lang, "format": "srt"}
                     if self.api_key:
                         data["api_key"] = self.api_key
                     resp = self.session.post(


### PR DESCRIPTION
## Summary
- allow configuring LibreTranslateClient with a source language
- pass configured source language from CLI config
- ensure POST payload includes configured source language

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a07b767d4c832db90a9f157a062b73