### PR TITLE
Use file close events to trigger translations

### DIFF
--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -1,6 +1,6 @@
 import logging
 
-from watchdog.events import FileCreatedEvent, FileModifiedEvent, FileMovedEvent
+from watchdog import events
 
 import babelarr.app as app_module
 from babelarr.app import SrtHandler
@@ -20,8 +20,8 @@ def test_srt_handler_enqueue(monkeypatch, tmp_path, app):
     monkeypatch.setattr(app_instance, "enqueue", fake_enqueue)
 
     handler = SrtHandler(app_instance)
-    event = FileCreatedEvent(str(path))
-    handler.on_created(event)
+    event = events.FileClosedEvent(str(path))
+    handler.on_closed(event)
 
     assert called["path"] == path
 
@@ -40,11 +40,30 @@ def test_srt_handler_enqueue_modified(monkeypatch, tmp_path, app):
     monkeypatch.setattr(app_instance, "enqueue", fake_enqueue)
 
     handler = SrtHandler(app_instance)
-    event = FileModifiedEvent(str(path))
-    handler.on_modified(event)
+    event = events.FileClosedEvent(str(path))
+    handler.on_closed(event)
 
     assert called["path"] == path
     assert not app_instance.output_path(path, "nl").exists()
+
+
+def test_srt_handler_ignore_closed_nowrite(monkeypatch, tmp_path, app):
+    path = tmp_path / "sample.en.srt"
+    path.write_text("example")
+
+    app_instance = app()
+    called = {}
+
+    def fake_enqueue(p):
+        called["path"] = p
+
+    monkeypatch.setattr(app_instance, "enqueue", fake_enqueue)
+
+    handler = SrtHandler(app_instance)
+    event = events.FileClosedNoWriteEvent(str(path))
+    handler.on_closed(event)
+
+    assert "path" not in called
 
 
 def test_srt_handler_enqueue_moved(monkeypatch, tmp_path, app):
@@ -62,75 +81,10 @@ def test_srt_handler_enqueue_moved(monkeypatch, tmp_path, app):
     monkeypatch.setattr(app_instance, "enqueue", fake_enqueue)
 
     handler = SrtHandler(app_instance)
-    event = FileMovedEvent(str(src), str(dest))
+    event = events.FileMovedEvent(str(src), str(dest))
     handler.on_moved(event)
 
     assert called["path"] == dest
-
-
-def test_srt_handler_debounce(monkeypatch, tmp_path, app):
-    path = tmp_path / "partial.en.srt"
-    path.write_text("part1")
-
-    called = {}
-    app_instance = app()
-    app_instance.config.debounce = 0.01
-
-    def fake_enqueue(p):
-        called["path"] = p
-
-    monkeypatch.setattr(app_instance, "enqueue", fake_enqueue)
-
-    handler = SrtHandler(app_instance)
-
-    import threading
-    import time
-
-    def append_later():
-        time.sleep(0.005)
-        with path.open("a") as fh:
-            fh.write("part2")
-
-    threading.Thread(target=append_later).start()
-    event = FileCreatedEvent(str(path))
-    handler.on_created(event)
-
-    assert called["path"] == path
-    assert path.read_text() == "part1part2"
-
-
-def test_srt_handler_timeout(monkeypatch, tmp_path, app, caplog):
-    path = tmp_path / "waiting.en.srt"
-    path.write_text("initial")
-
-    called = {}
-    app_instance = app()
-    app_instance.config.debounce = 0.01
-
-    def fake_enqueue(p):
-        called["path"] = p
-
-    monkeypatch.setattr(app_instance, "enqueue", fake_enqueue)
-
-    handler = SrtHandler(app_instance)
-    handler._max_wait = 0.05
-
-    from itertools import count
-    from types import SimpleNamespace
-
-    sizes = count(1)
-
-    def fake_stat(self):
-        return SimpleNamespace(st_size=next(sizes))
-
-    monkeypatch.setattr(type(path), "stat", fake_stat)
-
-    event = FileCreatedEvent(str(path))
-    with caplog.at_level(logging.WARNING):
-        handler.on_created(event)
-
-    assert "path" not in called
-    assert "timeout" in caplog.text.lower()
 
 
 def test_watch_lifecycle(monkeypatch, tmp_path, app):


### PR DESCRIPTION
## Summary
- replace file-stability polling with watchdog `FileClosedEvent` handling
- enqueue translations when subtitle files close after writing
- update tests for new event-driven behaviour

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a08faa0e98832d93ef889686e40876