### PR TITLE
ci: use Makefile targets in workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,26 +8,38 @@ on:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
-      - run: |
-          python -m pip install -U pip
-          pip install -e .
-          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
-      - uses: pre-commit/action@v3.0.1
+          python-version: ${{ matrix.python-version }}
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/requirements-dev.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+      - run: make setup
+      - run: make lint
 
   tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
-      - run: |
-          python -m pip install -U pip
-          pip install -e .
-          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
-      - run: pytest --maxfail=1 --disable-warnings -q
+          python-version: ${{ matrix.python-version }}
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/requirements-dev.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+      - run: make setup
+      - run: make test


### PR DESCRIPTION
## Summary
- simplify CI workflow by using Makefile targets for setup, lint and tests
- cache pip dependencies and test against Python 3.11 and 3.12

## Testing
- `make setup`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a0a62e1d74832db0296b4ebc31c134