### PR TITLE
feat: add LibreTranslate API wrapper

### DIFF
--- a/babelarr/libretranslate_api.py
+++ b/babelarr/libretranslate_api.py
@@ -1,0 +1,55 @@
+"""Thin wrapper around the LibreTranslate HTTP API."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import requests
+
+
+class LibreTranslateAPI:
+    """HTTP helper for a single LibreTranslate endpoint.
+
+    The client maintains a single :class:`requests.Session` shared across all
+    requests to ``base_url``.
+    """
+
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.session = requests.Session()
+
+    def fetch_languages(self) -> list[dict]:
+        """Return the languages supported by the server."""
+
+        url = self.base_url + "/languages"
+        resp = self.session.get(url, timeout=60)
+        resp.raise_for_status()
+        return resp.json()
+
+    def translate_file(
+        self,
+        path: Path,
+        src_lang: str,
+        target_lang: str,
+        api_key: str | None = None,
+    ) -> requests.Response:
+        """Translate *path* from *src_lang* into *target_lang*."""
+
+        data = {"source": src_lang, "target": target_lang, "format": "srt"}
+        if api_key:
+            data["api_key"] = api_key
+
+        url = self.base_url + "/translate_file"
+        with open(path, "rb") as fh:
+            files = {"file": fh}
+            return self.session.post(url, files=files, data=data, timeout=60)
+
+    def download(self, url: str) -> requests.Response:
+        """Download *url* using the shared session."""
+
+        return self.session.get(url, timeout=60)
+
+    async def close(self) -> None:
+        """Asynchronously close the underlying session."""
+
+        self.session.close()

--- a/tests/test_libretranslate_api.py
+++ b/tests/test_libretranslate_api.py
@@ -1,0 +1,79 @@
+import asyncio
+
+import pytest
+import requests
+
+from babelarr.libretranslate_api import LibreTranslateAPI
+
+
+def test_fetch_languages(monkeypatch):
+    def fake_get(self, url, *, timeout=60):
+        assert url == "http://only/languages"
+        resp = requests.Response()
+        resp.status_code = 200
+        resp._content = b"[]"
+        return resp
+
+    monkeypatch.setattr(requests.Session, "get", fake_get)
+
+    api = LibreTranslateAPI("http://only")
+    languages = api.fetch_languages()
+
+    assert languages == []
+
+    asyncio.run(api.close())
+
+
+def test_fetch_languages_error(monkeypatch):
+    def fake_get(self, url, *, timeout=60):
+        raise requests.ConnectionError("boom")
+
+    monkeypatch.setattr(requests.Session, "get", fake_get)
+
+    api = LibreTranslateAPI("http://only")
+
+    with pytest.raises(requests.ConnectionError):
+        api.fetch_languages()
+
+    asyncio.run(api.close())
+
+
+def test_translate_file_error(monkeypatch, tmp_path):
+    tmp_file = tmp_path / "a.srt"
+    tmp_file.write_text("dummy")
+
+    def fake_post(self, url, *, files=None, data=None, timeout=60):
+        raise requests.ConnectionError("fail")
+
+    monkeypatch.setattr(requests.Session, "post", fake_post)
+
+    api = LibreTranslateAPI("http://only")
+
+    with pytest.raises(requests.ConnectionError):
+        api.translate_file(tmp_file, "en", "nl")
+
+    asyncio.run(api.close())
+
+
+def test_translate_file(monkeypatch, tmp_path):
+    tmp_file = tmp_path / "b.srt"
+    tmp_file.write_text("dummy")
+
+    calls: list[str] = []
+
+    def fake_post(self, url, *, files=None, data=None, timeout=60):
+        calls.append(url)
+        resp = requests.Response()
+        resp.status_code = 200
+        resp._content = b"ok"
+        return resp
+
+    monkeypatch.setattr(requests.Session, "post", fake_post)
+
+    api = LibreTranslateAPI("http://only")
+    resp = api.translate_file(tmp_file, "en", "nl")
+
+    assert calls == ["http://only/translate_file"]
+    assert resp.content == b"ok"
+
+    asyncio.run(api.close())


### PR DESCRIPTION
## Summary
- wrap LibreTranslate HTTP calls in a reusable client
- reuse one session with a single base URL
- update translator to use wrapper
- test API wrapper for error paths and single endpoint usage

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a0b7f81a1c832d8706a0a6b8378606