### PR TITLE
feat: pause workers until LibreTranslate is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Queued translation tasks are stored in a small SQLite database (`/config/queue.d
 
 The application scans for new source-language subtitles on startup, upon file creation and at a configurable interval (default every 60 minutes) thereafter. Translated subtitles are saved beside the source file with language suffixes (e.g. `.nl.srt`, `.bs.srt`). Existing subtitles that are modified or moved are re-queued for translation after a short debounce to ensure the file is fully written.
 
+If LibreTranslate is unreachable at startup or during operation, Babelarr logs the outage and pauses worker threads until the service becomes available again.
+
 The container runs as a non-root user with UID and GID `1000`. Ensure the host paths mounted at `/data` and `/config` are writable by this user.
 
 Example `docker-compose.yml`:

--- a/babelarr/cli.py
+++ b/babelarr/cli.py
@@ -17,8 +17,8 @@ def validate_environment(config: Config) -> None:
 
     Updates ``config.root_dirs`` to only include readable directories. If none
     remain, the process exits with a clear error. The translation service is
-    checked with a simple ``HEAD`` request and the process aborts if it is
-    unreachable.
+    probed with a ``HEAD`` request and any failure is logged, but startup
+    continues and workers will wait until the service becomes reachable.
     """
 
     valid_dirs: list[str] = []
@@ -43,8 +43,9 @@ def validate_environment(config: Config) -> None:
         if resp.status_code >= 400:
             raise requests.RequestException(f"HTTP {resp.status_code}")
     except requests.RequestException as exc:
-        logger.error("Translation service %s unreachable: %s", config.api_url, exc)
-        raise SystemExit(f"Translation service unreachable: {config.api_url}")
+        logger.error(
+            "Translation service %s unreachable at startup: %s", config.api_url, exc
+        )
 
 
 def main() -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,9 @@ class _DummyTranslator:
     def close(self):
         pass
 
+    def wait_until_available(self):
+        return None
+
 
 @pytest.fixture
 def config(tmp_path):

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -15,6 +15,9 @@ class DummyTranslator:
     def close(self):
         pass
 
+    def wait_until_available(self):
+        return None
+
 
 def test_translate_file(tmp_path, app):
     # Create a dummy English subtitle file
@@ -257,9 +260,9 @@ def test_unsupported_source_language(monkeypatch):
         return resp
 
     monkeypatch.setattr(requests.Session, "get", fake_get)
-
+    client = LibreTranslateClient("http://example", "zz")
     with pytest.raises(ValueError, match="Unsupported source language"):
-        LibreTranslateClient("http://example", "zz")
+        client.ensure_languages()
 
 
 def test_unsupported_target_language(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- continue startup when LibreTranslate is unreachable
- block worker threads until the translation service responds
- retry queued files once service returns

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a0bd8814f0832d9566ed17c49dae90