### PR TITLE
fix: isolate HTTP sessions per thread

### DIFF
--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -1,0 +1,48 @@
+import asyncio
+import threading
+
+import requests
+
+from babelarr.libretranslate_api import LibreTranslateAPI
+
+
+def test_translate_file_thread_safety(monkeypatch, tmp_path):
+    tmp_file = tmp_path / "a.srt"
+    tmp_file.write_text("dummy")
+
+    sessions: dict[int, requests.Session] = {}
+    lock = threading.Lock()
+
+    def fake_post(self, url, *, files=None, data=None, timeout=60):
+        with lock:
+            sessions[id(threading.current_thread())] = self
+        resp = requests.Response()
+        resp.status_code = 200
+        resp._content = b"ok"
+        return resp
+
+    monkeypatch.setattr(requests.Session, "post", fake_post)
+
+    api = LibreTranslateAPI("http://only")
+
+    results: list[bytes] = []
+    errors: list[Exception] = []
+
+    def worker():
+        try:
+            resp = api.translate_file(tmp_file, "en", "nl")
+            results.append(resp.content)
+        except Exception as exc:  # pragma: no cover - defensive
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(5)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not errors
+    assert results == [b"ok"] * 5
+    assert len({id(s) for s in sessions.values()}) == 5
+
+    asyncio.run(api.close())


### PR DESCRIPTION
## Summary
- use a thread-local requests.Session inside LibreTranslateAPI
- update HTTP helpers to fetch per-thread sessions
- test translate_file concurrency across threads

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a0d80b8910832d80f4be2e3b760ff1