### PR TITLE
feat: queue translations per language

### DIFF
--- a/babelarr/cli.py
+++ b/babelarr/cli.py
@@ -76,8 +76,8 @@ def main(argv: list[str] | None = None) -> None:
         count = repo.count()
         print(f"{count} pending item{'s' if count != 1 else ''}")
         if args.list:
-            for path in repo.all():
-                print(path)
+            for path, lang in repo.all():
+                print(f"{path} [{lang}]")
         repo.close()
         return
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -8,6 +8,7 @@ import pytest
 import requests
 
 from babelarr import cli
+from babelarr.app import TranslationTask
 from babelarr.config import Config
 
 
@@ -38,7 +39,7 @@ def test_db_persistence_across_restarts(tmp_path, app):
     app2 = app()
     app2.load_pending()
     restored = app2.tasks.get_nowait()
-    assert restored == src
+    assert restored == TranslationTask(src, "nl")
 
 
 def test_worker_retry_on_network_failure(tmp_path, caplog, app):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,8 +43,8 @@ def test_main_sets_watchdog_logger_to_info(monkeypatch):
 def test_queue_status_outputs_count_and_paths(tmp_path, monkeypatch, capsys):
     db_path = tmp_path / "queue.db"
     with QueueRepository(str(db_path)) as repo:
-        repo.add(tmp_path / "one")
-        repo.add(tmp_path / "two")
+        repo.add(tmp_path / "one", "nl")
+        repo.add(tmp_path / "two", "nl")
 
     config = Config(
         root_dirs=[],
@@ -60,4 +60,7 @@ def test_queue_status_outputs_count_and_paths(tmp_path, monkeypatch, capsys):
     cli.main(["queue", "--status", "--list"])
     out = capsys.readouterr().out.strip().splitlines()
     assert out[0] == "2 pending items"
-    assert set(out[1:]) == {str(tmp_path / "one"), str(tmp_path / "two")}
+    assert set(out[1:]) == {
+        f"{tmp_path / 'one'} [nl]",
+        f"{tmp_path / 'two'} [nl]",
+    }

--- a/tests/test_queue_db.py
+++ b/tests/test_queue_db.py
@@ -7,8 +7,8 @@ def test_count_returns_number_of_items(tmp_path):
     db_path = tmp_path / "queue.db"
     with QueueRepository(str(db_path)) as repo:
         assert repo.count() == 0
-        repo.add(Path("a"))
-        repo.add(Path("b"))
+        repo.add(Path("a"), "nl")
+        repo.add(Path("b"), "nl")
         assert repo.count() == 2
-        repo.remove(Path("a"))
+        repo.remove(Path("a"), "nl")
         assert repo.count() == 1

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -86,7 +86,7 @@ def test_srt_handler_delete_removes_from_queue(tmp_path, app):
 
     app_instance = app()
     app_instance.enqueue(path)
-    assert app_instance.db.all() == [path]
+    assert app_instance.db.all() == [(path, "nl")]
 
     path.unlink()
     handler = SrtHandler(app_instance)


### PR DESCRIPTION
## Summary
- queue individual TranslationTask objects for each missing language
- persist path/language pairs in queue_db and expose via CLI
- simplify worker to process tasks without inner thread pool

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a0da30b1b0832da8405cea021fb469