### PR TITLE
feat: show queue status without flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Queued translation tasks are stored in a small SQLite database (`/config/queue.d
 Check the current queue with:
 
 ```bash
-babelarr queue --status [--list]
+babelarr queue [--list]
 ```
 
 The command prints the number of pending items and, with `--list`, each queued path.

--- a/babelarr/cli.py
+++ b/babelarr/cli.py
@@ -55,9 +55,6 @@ def main(argv: list[str] | None = None) -> None:
     sub = parser.add_subparsers(dest="command")
 
     queue_parser = sub.add_parser("queue", help="Inspect the processing queue")
-    queue_parser.add_argument(
-        "--status", action="store_true", help="Show pending item count"
-    )
     queue_parser.add_argument("--list", action="store_true", help="List queued paths")
 
     args = parser.parse_args(argv)
@@ -69,8 +66,6 @@ def main(argv: list[str] | None = None) -> None:
     logging.getLogger("watchdog").setLevel(logging.INFO)
 
     if args.command == "queue":
-        if not args.status:
-            parser.error("queue command requires --status")
         config = Config.from_env()
         repo = QueueRepository(config.queue_db)
         count = repo.count()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,7 +40,7 @@ def test_main_sets_watchdog_logger_to_info(monkeypatch):
     assert logging.getLogger("watchdog").level == logging.INFO
 
 
-def test_queue_status_outputs_count_and_paths(tmp_path, monkeypatch, capsys):
+def test_queue_outputs_count_and_paths(tmp_path, monkeypatch, capsys):
     db_path = tmp_path / "queue.db"
     with QueueRepository(str(db_path)) as repo:
         repo.add(tmp_path / "one", "nl")
@@ -57,10 +57,32 @@ def test_queue_status_outputs_count_and_paths(tmp_path, monkeypatch, capsys):
     )
 
     monkeypatch.setattr(cli.Config, "from_env", classmethod(lambda cls: config))
-    cli.main(["queue", "--status", "--list"])
+    cli.main(["queue", "--list"])
     out = capsys.readouterr().out.strip().splitlines()
     assert out[0] == "2 pending items"
     assert set(out[1:]) == {
         f"{tmp_path / 'one'} [nl]",
         f"{tmp_path / 'two'} [nl]",
     }
+
+
+def test_queue_outputs_count(tmp_path, monkeypatch, capsys):
+    db_path = tmp_path / "queue.db"
+    with QueueRepository(str(db_path)) as repo:
+        repo.add(tmp_path / "one", "nl")
+        repo.add(tmp_path / "two", "nl")
+
+    config = Config(
+        root_dirs=[],
+        target_langs=[],
+        src_lang="en",
+        src_ext=".en.srt",
+        api_url="http://example",
+        workers=1,
+        queue_db=str(db_path),
+    )
+
+    monkeypatch.setattr(cli.Config, "from_env", classmethod(lambda cls: config))
+    cli.main(["queue"])
+    out = capsys.readouterr().out.strip().splitlines()
+    assert out == ["2 pending items"]


### PR DESCRIPTION
## Summary
- remove `--status` requirement from `queue` subcommand
- display pending count whenever `queue` runs and keep `--list` optional
- update docs and tests for new queue behavior

## Testing
- `make setup`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a0de0a0478832dab816496a8831a12