### PR TITLE
fix: error on empty target languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ docker run -d --name babelarr \
 | Variable | Default | Description |
 | --- | --- | --- |
 | `WATCH_DIRS` | `/data` | Colon-separated directories to scan for subtitles. |
-| `TARGET_LANGS` | `nl,bs` | Comma-separated language codes to translate into. |
+| `TARGET_LANGS` | `nl,bs` | Comma-separated language codes to translate into. Must include at least one valid code; startup fails if none remain after filtering. |
 | `SRC_LANG` | `en` | Two-letter source language of existing subtitles; files matching `*.LANG.srt` are processed. |
 | `LIBRETRANSLATE_URL` | `http://libretranslate:5000` | Base URL of the LibreTranslate instance (no path). |
 | `LIBRETRANSLATE_API_KEY` | *(unset)* | API key for authenticated LibreTranslate instances. |
@@ -40,6 +40,8 @@ docker run -d --name babelarr \
 | `BACKOFF_DELAY` | `1` | Initial delay between retries in seconds. |
 | `DEBOUNCE_SECONDS` | `0.1` | Wait time to ensure files have finished writing before enqueueing. |
 | `SCAN_INTERVAL_MINUTES` | `60` | Minutes between full directory scans. |
+
+If `TARGET_LANGS` is empty or only contains invalid entries, the application raises a `ValueError` during startup.
 
 `LIBRETRANSLATE_URL` should include only the protocol, hostname or IP, and port of your LibreTranslate instance. The `translate_file` API path is appended automatically.
 

--- a/babelarr/config.py
+++ b/babelarr/config.py
@@ -64,6 +64,12 @@ class Config:
             target_langs.append(normalized)
             seen.add(normalized)
 
+        if not target_langs:
+            logger.error("No valid languages found in TARGET_LANGS")
+            raise ValueError(
+                "TARGET_LANGS must contain at least one valid language code"
+            )
+
         src_lang = os.environ.get("SRC_LANG", "en").strip().lower()
         if not src_lang.isalpha():
             logger.warning("Invalid SRC_LANG '%s'; defaulting to 'en'", src_lang)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,9 @@
+import pytest
+
+from babelarr.config import Config
+
+
+def test_from_env_rejects_empty_target_langs(monkeypatch):
+    monkeypatch.setenv("TARGET_LANGS", "")
+    with pytest.raises(ValueError):
+        Config.from_env()


### PR DESCRIPTION
## Summary
- raise ValueError when TARGET_LANGS yields no valid languages
- document requirement for non-empty TARGET_LANGS
- test empty TARGET_LANGS handling

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a0de0b362c832d8f5d6cd0d49c6ae3