### PR TITLE
ci: detect merge conflicts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-${{ matrix.python-version }}-
       - run: make setup
+      - name: Check merge conflicts
+        run: |
+          git fetch origin main
+          git merge --no-commit --no-ff origin/main || { echo "Merge conflict detected"; exit 1; }
+          git merge --abort
       - run: make lint
 
   tests:
@@ -42,4 +47,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-${{ matrix.python-version }}-
       - run: make setup
+      - name: Check merge conflicts
+        run: |
+          git fetch origin main
+          git merge --no-commit --no-ff origin/main || { echo "Merge conflict detected"; exit 1; }
+          git merge --abort
       - run: make test


### PR DESCRIPTION
## Summary
- add merge conflict check step to CI workflow

## Testing
- `make setup`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a0e5fbf5a4832dae25250ba9cfbe98