### PR TITLE
feat: log skipped translations

### DIFF
--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -10,6 +10,7 @@ def test_enqueue_and_worker(tmp_path, monkeypatch, app, config):
 
     def fake_translate_file(src, lang):
         app_instance.output_path(src, lang).write_text("Hallo")
+        return True
 
     monkeypatch.setattr(app_instance, "translate_file", fake_translate_file)
 
@@ -33,6 +34,7 @@ def test_enqueue_uppercase_extension(tmp_path, monkeypatch, app, config):
 
     def fake_translate_file(src, lang):
         app_instance.output_path(src, lang).write_text("Hallo")
+        return True
 
     monkeypatch.setattr(app_instance, "translate_file", fake_translate_file)
 

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -27,7 +27,7 @@ def test_translate_file(tmp_path, app):
     translator = DummyTranslator()
     app_instance = app(translator=translator)
 
-    app_instance.translate_file(tmp_file, "nl")
+    assert app_instance.translate_file(tmp_file, "nl") is True
     output_file = app_instance.output_path(tmp_file, "nl")
     assert output_file.exists()
     assert output_file.read_bytes() == translator.result


### PR DESCRIPTION
## Summary
- have translate_file report success/failure
- log Skipped translations when output is not written
- test worker logging and queue updates for skipped translations

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a0ed17f100832db97879dd111cb047