### PR TITLE
fix: silence urllib3 logging

### DIFF
--- a/babelarr/cli.py
+++ b/babelarr/cli.py
@@ -64,6 +64,7 @@ def main(argv: list[str] | None = None) -> None:
         format="%(asctime)s [%(levelname)s] %(message)s",
     )
     logging.getLogger("watchdog").setLevel(logging.INFO)
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
 
     if args.command == "queue":
         config = Config.from_env()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,6 +40,40 @@ def test_main_sets_watchdog_logger_to_info(monkeypatch):
     assert logging.getLogger("watchdog").level == logging.INFO
 
 
+def test_main_sets_urllib3_logger_to_warning(monkeypatch):
+    config = Config(
+        root_dirs=["/tmp"],
+        target_langs=["nl"],
+        src_lang="en",
+        src_ext=".en.srt",
+        api_url="http://example",
+        workers=1,
+        queue_db=":memory:",
+    )
+
+    monkeypatch.setattr(cli.Config, "from_env", classmethod(lambda cls: config))
+    monkeypatch.setattr(cli, "validate_environment", lambda cfg: None)
+
+    class DummyApp:
+        def __init__(self, *args, **kwargs):
+            self.shutdown_event = types.SimpleNamespace(set=lambda: None)
+
+        def run(self) -> None:  # pragma: no cover - does nothing
+            return None
+
+    monkeypatch.setattr(cli, "Application", DummyApp)
+    monkeypatch.setattr(cli, "LibreTranslateClient", lambda *a, **k: object())
+
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    logging.getLogger().handlers.clear()
+    logging.getLogger().setLevel(logging.NOTSET)
+    logging.getLogger("urllib3").setLevel(logging.NOTSET)
+
+    cli.main([])
+
+    assert logging.getLogger("urllib3").level == logging.WARNING
+
+
 def test_queue_outputs_count_and_paths(tmp_path, monkeypatch, capsys):
     db_path = tmp_path / "queue.db"
     with QueueRepository(str(db_path)) as repo:


### PR DESCRIPTION
## Summary
- silence noisy urllib3 connection reset logs
- test CLI logging sets urllib3 logger to WARNING

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a0ed1f2bcc832dbd6f2200bed7a2fd