### PR TITLE
fix: ignore unsupported target languages

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,8 @@
 import logging
 import types
 
+import pytest
+
 from babelarr import cli
 from babelarr.config import Config
 from babelarr.queue_db import QueueRepository
@@ -28,7 +30,15 @@ def test_main_sets_watchdog_logger_to_info(monkeypatch):
             return None
 
     monkeypatch.setattr(cli, "Application", DummyApp)
-    monkeypatch.setattr(cli, "LibreTranslateClient", lambda *a, **k: object())
+
+    class DummyTranslator:
+        def __init__(self, *args, **kwargs):
+            self.supported_targets = {"nl"}
+
+        def ensure_languages(self):
+            return None
+
+    monkeypatch.setattr(cli, "LibreTranslateClient", DummyTranslator)
 
     monkeypatch.setenv("LOG_LEVEL", "DEBUG")
     logging.getLogger().handlers.clear()
@@ -62,7 +72,15 @@ def test_main_sets_urllib3_logger_to_warning(monkeypatch):
             return None
 
     monkeypatch.setattr(cli, "Application", DummyApp)
-    monkeypatch.setattr(cli, "LibreTranslateClient", lambda *a, **k: object())
+
+    class DummyTranslator:
+        def __init__(self, *args, **kwargs):
+            self.supported_targets = {"nl"}
+
+        def ensure_languages(self):
+            return None
+
+    monkeypatch.setattr(cli, "LibreTranslateClient", DummyTranslator)
 
     monkeypatch.setenv("LOG_LEVEL", "DEBUG")
     logging.getLogger().handlers.clear()
@@ -120,3 +138,53 @@ def test_queue_outputs_count(tmp_path, monkeypatch, capsys):
     cli.main(["queue"])
     out = capsys.readouterr().out.strip().splitlines()
     assert out == ["2 pending items"]
+
+
+def test_filter_target_languages_removes_unsupported(caplog):
+    config = Config(
+        root_dirs=["/tmp"],
+        target_langs=["nl", "xx"],
+        src_lang="en",
+        src_ext=".en.srt",
+        api_url="http://example",
+        workers=1,
+        queue_db=":memory:",
+    )
+
+    class DummyTranslator:
+        def __init__(self):
+            self.supported_targets = {"nl"}
+
+        def ensure_languages(self):
+            return None
+
+    translator = DummyTranslator()
+
+    with caplog.at_level(logging.WARNING):
+        cli.filter_target_languages(config, translator)
+        assert config.target_langs == ["nl"]
+        assert "unsupported target" in caplog.text.lower()
+
+
+def test_filter_target_languages_exits_when_none_supported():
+    config = Config(
+        root_dirs=["/tmp"],
+        target_langs=["xx"],
+        src_lang="en",
+        src_ext=".en.srt",
+        api_url="http://example",
+        workers=1,
+        queue_db=":memory:",
+    )
+
+    class DummyTranslator:
+        def __init__(self):
+            self.supported_targets = set()
+
+        def ensure_languages(self):
+            return None
+
+    translator = DummyTranslator()
+
+    with pytest.raises(SystemExit):
+        cli.filter_target_languages(config, translator)


### PR DESCRIPTION
## Summary
- filter out unsupported target languages during startup
- exit if no supported target languages remain
- test CLI filtering logic

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a0f68733a0832d950ffb9bc6d195f0