### PR TITLE
fix: increase translate_file timeout

### DIFF
--- a/babelarr/libretranslate_api.py
+++ b/babelarr/libretranslate_api.py
@@ -56,7 +56,7 @@ class LibreTranslateAPI:
         url = self.base_url + "/translate_file"
         with open(path, "rb") as fh:
             files = {"file": fh}
-            return self.session.post(url, files=files, data=data, timeout=60)
+            return self.session.post(url, files=files, data=data, timeout=900)
 
     def download(self, url: str) -> requests.Response:
         """Download *url* using the thread-local session."""

--- a/tests/test_libretranslate_api.py
+++ b/tests/test_libretranslate_api.py
@@ -59,10 +59,11 @@ def test_translate_file(monkeypatch, tmp_path):
     tmp_file = tmp_path / "b.srt"
     tmp_file.write_text("dummy")
 
-    calls: list[str] = []
+    calls: list[tuple[str, int]] = []
 
-    def fake_post(self, url, *, files=None, data=None, timeout=60):
-        calls.append(url)
+    def fake_post(self, url, *, files=None, data=None, timeout):
+        calls.append((url, timeout))
+        assert timeout == 900
         resp = requests.Response()
         resp.status_code = 200
         resp._content = b"ok"
@@ -73,7 +74,7 @@ def test_translate_file(monkeypatch, tmp_path):
     api = LibreTranslateAPI("http://only")
     resp = api.translate_file(tmp_file, "en", "nl")
 
-    assert calls == ["http://only/translate_file"]
+    assert calls == [("http://only/translate_file", 900)]
     assert resp.content == b"ok"
 
     asyncio.run(api.close())


### PR DESCRIPTION
## Summary
- extend translate_file HTTP timeout to accommodate large uploads
- verify longer timeout through updated LibreTranslate API tests

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a107d8fa30832d8555a07d0ed87147