### PR TITLE
fix: raise LibreTranslate timeouts

### DIFF
--- a/babelarr/cli.py
+++ b/babelarr/cli.py
@@ -41,7 +41,7 @@ def validate_environment(config: Config) -> None:
     config.root_dirs = valid_dirs
 
     try:
-        resp = requests.head(config.api_url, timeout=5)
+        resp = requests.head(config.api_url, timeout=900)
         if resp.status_code >= 400:
             raise requests.RequestException(f"HTTP {resp.status_code}")
     except requests.RequestException as exc:

--- a/babelarr/libretranslate_api.py
+++ b/babelarr/libretranslate_api.py
@@ -36,7 +36,7 @@ class LibreTranslateAPI:
         """Return the languages supported by the server."""
 
         url = self.base_url + "/languages"
-        resp = self.session.get(url, timeout=60)
+        resp = self.session.get(url, timeout=900)
         resp.raise_for_status()
         return resp.json()
 
@@ -61,7 +61,7 @@ class LibreTranslateAPI:
     def download(self, url: str) -> requests.Response:
         """Download *url* using the thread-local session."""
 
-        return self.session.get(url, timeout=60)
+        return self.session.get(url, timeout=900)
 
     async def close(self) -> None:
         """Asynchronously close the thread-local session for this thread."""

--- a/babelarr/translator.py
+++ b/babelarr/translator.py
@@ -62,7 +62,7 @@ class LibreTranslateClient:
     def is_available(self) -> bool:
         """Return ``True`` if the service responds without error."""
         try:
-            resp = self.api.session.head(self.api.base_url, timeout=5)
+            resp = self.api.session.head(self.api.base_url, timeout=900)
             return resp.status_code < 400
         except requests.RequestException:
             return False

--- a/tests/test_libretranslate_api.py
+++ b/tests/test_libretranslate_api.py
@@ -7,8 +7,9 @@ from babelarr.libretranslate_api import LibreTranslateAPI
 
 
 def test_fetch_languages(monkeypatch):
-    def fake_get(self, url, *, timeout=60):
+    def fake_get(self, url, *, timeout=900):
         assert url == "http://only/languages"
+        assert timeout == 900
         resp = requests.Response()
         resp.status_code = 200
         resp._content = b"[]"
@@ -25,7 +26,8 @@ def test_fetch_languages(monkeypatch):
 
 
 def test_fetch_languages_error(monkeypatch):
-    def fake_get(self, url, *, timeout=60):
+    def fake_get(self, url, *, timeout=900):
+        assert timeout == 900
         raise requests.ConnectionError("boom")
 
     monkeypatch.setattr(requests.Session, "get", fake_get)
@@ -42,7 +44,8 @@ def test_translate_file_error(monkeypatch, tmp_path):
     tmp_file = tmp_path / "a.srt"
     tmp_file.write_text("dummy")
 
-    def fake_post(self, url, *, files=None, data=None, timeout=60):
+    def fake_post(self, url, *, files=None, data=None, timeout=900):
+        assert timeout == 900
         raise requests.ConnectionError("fail")
 
     monkeypatch.setattr(requests.Session, "post", fake_post)

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -13,7 +13,8 @@ def test_translate_file_thread_safety(monkeypatch, tmp_path):
     sessions: dict[int, requests.Session] = {}
     lock = threading.Lock()
 
-    def fake_post(self, url, *, files=None, data=None, timeout=60):
+    def fake_post(self, url, *, files=None, data=None, timeout=900):
+        assert timeout == 900
         with lock:
             sessions[id(threading.current_thread())] = self
         resp = requests.Response()


### PR DESCRIPTION
## Summary
- ensure all LibreTranslate requests use a 900s timeout
- update tests to expect the longer timeout

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a10a723f2c832daf140909574ca79b