### PR TITLE
feat: add worker names to logging

### DIFF
--- a/babelarr/cli.py
+++ b/babelarr/cli.py
@@ -95,7 +95,7 @@ def main(argv: list[str] | None = None) -> None:
 
     logging.basicConfig(
         level=os.environ.get("LOG_LEVEL", "INFO").upper(),
-        format="%(asctime)s [%(levelname)s] %(message)s",
+        format="%(asctime)s [%(levelname)s] [%(threadName)s] %(message)s",
     )
     logging.getLogger("watchdog").setLevel(logging.INFO)
     logging.getLogger("urllib3").setLevel(logging.WARNING)


### PR DESCRIPTION
## Summary
- name worker threads and include their names in log messages
- show thread names in CLI log output
- test logging includes worker names

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a1b278771c832d833a2279cac4516c