### PR TITLE
feat: add CLI logging options

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ docker run -d --name babelarr \
   -e TARGET_LANGS="nl,bs" \
   -e LIBRETRANSLATE_URL="http://libretranslate:5000" \
   -e LOG_LEVEL="INFO" \
+  -e LOG_FILE="/config/babelarr.log" \
   babelarr
 ```
 
@@ -35,6 +36,7 @@ docker run -d --name babelarr \
 | `LIBRETRANSLATE_URL` | `http://libretranslate:5000` | Base URL of the LibreTranslate instance (no path). |
 | `LIBRETRANSLATE_API_KEY` | *(unset)* | API key for authenticated LibreTranslate instances. |
 | `LOG_LEVEL` | `INFO` | Controls verbosity of console output. |
+| `LOG_FILE` | *(unset)* | If set, writes logs to the specified file. |
 | `WORKERS` | `1` | Number of translation worker threads (maximum 10). |
 | `RETRY_COUNT` | `3` | Translation retry attempts. |
 | `BACKOFF_DELAY` | `1` | Initial delay between retries in seconds. |
@@ -42,6 +44,8 @@ docker run -d --name babelarr \
 | `SCAN_INTERVAL_MINUTES` | `60` | Minutes between full directory scans. |
 
 If `TARGET_LANGS` is empty or only contains invalid entries, the application raises a `ValueError` during startup.
+
+Command-line options `--log-level` and `--log-file` override the `LOG_LEVEL` and `LOG_FILE` environment variables respectively.
 
 `LIBRETRANSLATE_URL` should include only the protocol, hostname or IP, and port of your LibreTranslate instance. The `translate_file` API path is appended automatically.
 

--- a/babelarr/cli.py
+++ b/babelarr/cli.py
@@ -86,6 +86,12 @@ def filter_target_languages(config: Config, translator: LibreTranslateClient) ->
 
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(prog="babelarr")
+    parser.add_argument(
+        "--log-level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Set logging level",
+    )
+    parser.add_argument("--log-file", help="Write logs to a file")
     sub = parser.add_subparsers(dest="command")
 
     queue_parser = sub.add_parser("queue", help="Inspect the processing queue")
@@ -93,8 +99,11 @@ def main(argv: list[str] | None = None) -> None:
 
     args = parser.parse_args(argv)
 
+    log_level = (args.log_level or os.environ.get("LOG_LEVEL", "INFO")).upper()
+    log_file = args.log_file or os.environ.get("LOG_FILE")
     logging.basicConfig(
-        level=os.environ.get("LOG_LEVEL", "INFO").upper(),
+        level=log_level,
+        filename=log_file,
         format="%(asctime)s [%(levelname)s] [%(threadName)s] %(message)s",
     )
     logging.getLogger("watchdog").setLevel(logging.INFO)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,6 +92,25 @@ def test_main_sets_urllib3_logger_to_warning(monkeypatch):
     assert logging.getLogger("urllib3").level == logging.WARNING
 
 
+def test_log_level_debug_enables_debug_output(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("QUEUE_DB", str(tmp_path / "queue.db"))
+    logging.getLogger().handlers.clear()
+    logging.getLogger().setLevel(logging.NOTSET)
+    cli.main(["--log-level", "DEBUG", "queue"])
+    captured = capsys.readouterr()
+    assert "Config:" in captured.err
+
+
+def test_log_file_option_creates_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUEUE_DB", str(tmp_path / "queue.db"))
+    log_file = tmp_path / "test.log"
+    logging.getLogger().handlers.clear()
+    logging.getLogger().setLevel(logging.NOTSET)
+    cli.main(["--log-level", "DEBUG", "--log-file", str(log_file), "queue"])
+    assert log_file.exists()
+    assert log_file.read_text() != ""
+
+
 def test_queue_outputs_count_and_paths(tmp_path, monkeypatch, capsys):
     db_path = tmp_path / "queue.db"
     with QueueRepository(str(db_path)) as repo:


### PR DESCRIPTION
## Summary
- add `--log-level` and `--log-file` CLI options
- configure logging using CLI flags or env vars
- document logging options and test debug/file logging

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a1b5a87a30832d82e0c2a048eb616f