### PR TITLE
fix: ignore modified SRT events

### DIFF
--- a/babelarr/app.py
+++ b/babelarr/app.py
@@ -83,13 +83,8 @@ class SrtHandler(PatternMatchingEventHandler):
         self.app.db.remove(Path(event.src_path))
 
     def on_modified(self, event):
-        path = Path(event.src_path)
-        logger.debug("Detected modified file %s", path)
-        for lang in self.app.config.target_langs:
-            out = self.app.output_path(path, lang)
-            if out.exists():
-                out.unlink()
-        self._handle(path)
+        """Ignore file modification events."""
+        return
 
     def on_moved(self, event):
         dest = Path(event.dest_path)

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -39,11 +39,12 @@ def test_srt_handler_enqueue(monkeypatch, tmp_path, app):
     assert called["path"] == path
 
 
-def test_srt_handler_enqueue_modified(monkeypatch, tmp_path, app):
+def test_srt_handler_ignore_modified(monkeypatch, tmp_path, app):
     path = tmp_path / "sample.en.srt"
     path.write_text("example")
     app_instance = app()
-    app_instance.output_path(path, "nl").write_text("old")
+    output = app_instance.output_path(path, "nl")
+    output.write_text("old")
 
     called = {}
 
@@ -56,8 +57,8 @@ def test_srt_handler_enqueue_modified(monkeypatch, tmp_path, app):
     event = FileModifiedEvent(str(path))
     handler.dispatch(event)
 
-    assert called["path"] == path
-    assert not app_instance.output_path(path, "nl").exists()
+    assert "path" not in called
+    assert output.exists() and output.read_text() == "old"
 
 
 def test_srt_handler_enqueue_moved(monkeypatch, tmp_path, app):


### PR DESCRIPTION
## Summary
- ignore filesystem modification events
- adjust watcher tests for new behavior

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a1b6aa1a10832daedc2a0a3c0cde28