### PR TITLE
docs: expand README with local usage and licensing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Babelarr contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,26 @@
 
 A lightweight subtitle translator that watches directories for subtitle files in a configurable source language (default `.en.srt`) and uses [LibreTranslate](https://libretranslate.com/) to generate translations such as Dutch and Bosnian. Files are discovered through a watchdog and periodic scans, queued, and translated sequentially.
 
+## Prerequisites
+
+- Python 3.12 or newer
+
 ## Usage and Installation
+
+### Quick Start (Non-Docker)
+
+Install Babelarr and its dependencies locally and configure the required environment variables:
+
+```bash
+pip install -e .  # or: pip install babelarr
+
+export WATCH_DIRS="/path/to/subtitles"
+export LIBRETRANSLATE_URL="http://localhost:5000"
+
+babelarr
+```
+
+### Docker
 
 Build the container:
 
@@ -40,6 +59,8 @@ docker run -d --name babelarr \
 | `BACKOFF_DELAY` | `1` | Initial delay between retries in seconds. |
 | `DEBOUNCE_SECONDS` | `0.1` | Wait time to ensure files have finished writing before enqueueing. |
 | `SCAN_INTERVAL_MINUTES` | `60` | Minutes between full directory scans. |
+| `AVAILABILITY_CHECK_INTERVAL` | `30` | Seconds between checks for LibreTranslate availability. |
+| `QUEUE_DB` | `/config/queue.db` | Path to the SQLite queue database. |
 
 If `TARGET_LANGS` is empty or only contains invalid entries, the application raises a `ValueError` during startup.
 
@@ -91,23 +112,17 @@ services:
 
 ## Development
 
-Run the test suite with [pytest](https://docs.pytest.org/):
+The provided Makefile wraps common development tasks:
 
 ```bash
-pytest
+make setup  # install dev dependencies and pre-commit hooks
+make lint   # format and lint the codebase
+make test   # run the test suite
+make check  # lint and tests together
 ```
 
-This project uses [pre-commit](https://pre-commit.com/) to lint and type-check the codebase.
+These targets invoke [pre-commit](https://pre-commit.com/) and [pytest](https://docs.pytest.org/) under the hood.
 
-Install the hooks:
+## License
 
-```bash
-pip install pre-commit
-pre-commit install
-```
-
-Run all checks:
-
-```bash
-pre-commit run --all-files
-```
+This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- document Python 3.12 requirement and add non-Docker quick start
- list AVAILABILITY_CHECK_INTERVAL and QUEUE_DB environment variables
- switch development guidance to Makefile targets and add MIT license section

## Testing
- `make setup`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a1b45a8710832dba9de01edeb0d77f