### PR TITLE
feat: add task id to translation tasks

### DIFF
--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -8,7 +8,7 @@ def test_enqueue_and_worker(tmp_path, monkeypatch, app, config):
     config.src_ext = ".srt"
     app_instance = app(cfg=config)
 
-    def fake_translate_file(src, lang):
+    def fake_translate_file(src, lang, task_id=None):
         app_instance.output_path(src, lang).write_text("Hallo")
         return True
 
@@ -32,7 +32,7 @@ def test_enqueue_uppercase_extension(tmp_path, monkeypatch, app, config):
     config.src_ext = ".srt"
     app_instance = app(cfg=config)
 
-    def fake_translate_file(src, lang):
+    def fake_translate_file(src, lang, task_id=None):
         app_instance.output_path(src, lang).write_text("Hallo")
         return True
 


### PR DESCRIPTION
## Summary
- assign a unique `task_id` to each `TranslationTask`
- include `task_id` in queue, worker, and file translation logs
- adjust tests for the new task identifier

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a1bbfa0d00832db97745a41c46d978