### PR TITLE
docs: document LibreTranslate API wrapper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,9 @@ Only open/update the PR if **all** steps succeed. Otherwise, fix and re-run `mak
   - `app.py` → Application orchestration, filesystem watcher, worker pool, queueing.
   - `cli.py` → CLI startup, environment validation, logging config, signal handling.
   - `config.py` → All environment/config parsing (`Config.from_env()`).
+  - `libretranslate_api.py` → Thin HTTP wrapper around LibreTranslate; manages raw
+    requests and thread-local sessions. Consumed by `translator.py`, which handles
+    translation logic, retries, and backoff.
   - `queue_db.py` → SQLite queue repository; thread-safe access to queued paths.
   - `translator.py` → `Translator` protocol and `LibreTranslateClient` implementation (retries/backoff).
   - `__init__.py` → Public exports.


### PR DESCRIPTION
## Summary
- document `libretranslate_api.py` as thin HTTP wrapper used by `translator.py`

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a1d20fdffc832da316fe341de81a8b