### PR TITLE
feat: add task context to logs

### DIFF
--- a/babelarr/config.py
+++ b/babelarr/config.py
@@ -3,7 +3,7 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
-logger = logging.getLogger("babelarr")
+logger = logging.getLogger(__name__)
 
 
 @dataclass

--- a/babelarr/translator.py
+++ b/babelarr/translator.py
@@ -12,7 +12,7 @@ import requests
 
 from .libretranslate_api import LibreTranslateAPI
 
-logger = logging.getLogger("babelarr")
+logger = logging.getLogger(__name__)
 
 ERROR_MESSAGES = {
     400: "Bad Request",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -150,8 +150,9 @@ def test_worker_logs_processing_time(tmp_path, caplog, app):
     assert any(
         rec.levelno == logging.DEBUG
         and "finished processing" in rec.message.lower()
-        and str(src) in rec.message
-        and "[nl]" in rec.message
+        and rec.path == str(src)
+        and rec.lang == "nl"
+        and rec.task_id not in (None, "-")
         for rec in caplog.records
     )
 
@@ -172,8 +173,11 @@ def test_worker_translating_logged_as_debug(tmp_path, caplog, app):
 
     assert any(
         rec.levelno == logging.DEBUG
-        and rec.message.startswith("Worker worker_0")
+        and rec.threadName == "worker_0"
+        and rec.message.startswith("Worker")
         and re.search(r"\btranslating\b", rec.message)
+        and rec.path == str(src)
+        and rec.lang == "nl"
         for rec in caplog.records
     )
     assert not any(
@@ -202,11 +206,11 @@ def test_translation_logs_summary_once(tmp_path, caplog, app):
         if rec.levelno == logging.INFO and rec.message.startswith("translation ")
     ]
     assert len(info_logs) == 1
-    msg = info_logs[0].message
-    assert str(src) in msg
-    assert "nl" in msg
-    assert "succeeded" in msg
-    assert re.search(r"in \d+\.\d+s", msg)
+    rec = info_logs[0]
+    assert rec.path == str(src)
+    assert rec.lang == "nl"
+    assert "succeeded" in rec.message
+    assert re.search(r"in \d+\.\d+s", rec.message)
 
 
 def test_workers_wait_when_translator_unavailable(tmp_path, app):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -99,6 +99,7 @@ def test_log_level_debug_enables_debug_output(tmp_path, monkeypatch, capsys):
     cli.main(["--log-level", "DEBUG", "queue"])
     captured = capsys.readouterr()
     assert "Config:" in captured.err
+    assert "[babelarr.config]" in captured.err
 
 
 def test_log_file_option_creates_file(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add task-aware logger adapter carrying task_id, path, and lang
- simplify worker and translation logging to rely on contextual fields
- expose task context in CLI log format and ensure default values for all records

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68a1c5f82dfc832daebc6e63e489b180