### PR TITLE
feat: persist task priority

### DIFF
--- a/babelarr/app.py
+++ b/babelarr/app.py
@@ -264,7 +264,7 @@ class Application:
                     "Translation already exists: %s", self.output_path(path, lang)
                 )
                 continue
-            if self.db.add(path, lang):
+            if self.db.add(path, lang, priority):
                 queued_any = True
                 task_id = uuid4().hex
                 task = TranslationTask(path, lang, task_id, priority)
@@ -311,9 +311,9 @@ class Application:
 
     def load_pending(self):
         logger.info("Loading pending tasks")
-        for path, lang in self.db.all():
-            task = TranslationTask(path, lang, uuid4().hex)
-            self.tasks.put((task.priority, self._task_counter, task))
+        for path, lang, priority in self.db.all():
+            task = TranslationTask(path, lang, uuid4().hex, priority)
+            self.tasks.put((priority, self._task_counter, task))
             self._task_counter += 1
             logger.info("restored %s to %s id=%s", path, lang, task.task_id)
             self._ensure_workers()

--- a/babelarr/cli.py
+++ b/babelarr/cli.py
@@ -115,7 +115,7 @@ def main(argv: list[str] | None = None) -> None:
         count = repo.count()
         print(f"{count} pending item{'s' if count != 1 else ''}")
         if args.list:
-            for path, lang in repo.all():
+            for path, lang, _ in repo.all():
                 print(f"{path} [{lang}]")
         repo.close()
         return

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -89,11 +89,19 @@ def test_db_persistence_across_restarts(tmp_path, app):
     src.write_text("hello")
 
     app1 = app()
-    app1.enqueue(src)
+    app1._ensure_workers = lambda: None
+    app1.enqueue(src, priority=5)
 
     app2 = app()
+    app2._ensure_workers = lambda: None
     app2.load_pending()
-    app2.tasks.join()
+    assert app2.tasks.queue[0][0] == 5
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        executor.submit(app2.worker)
+        app2.tasks.join()
+        app2.shutdown_event.set()
+
     assert app2.output_path(src, "nl").exists()
 
 

--- a/tests/test_queue_db.py
+++ b/tests/test_queue_db.py
@@ -12,3 +12,12 @@ def test_count_returns_number_of_items(tmp_path):
         assert repo.count() == 2
         repo.remove(Path("a"), "nl")
         assert repo.count() == 1
+
+
+def test_add_stores_priority(tmp_path):
+    db_path = tmp_path / "queue.db"
+    with QueueRepository(str(db_path)) as repo:
+        repo.add(Path("a"), "nl", priority=5)
+        repo.add(Path("b"), "nl")
+        rows = sorted(repo.all(), key=lambda r: r[0])
+        assert rows == [(Path("a"), "nl", 5), (Path("b"), "nl", 0)]

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -127,7 +127,7 @@ def test_srt_handler_delete_removes_from_queue(tmp_path, app):
     app_instance = app(translator=translator)
     app_instance.enqueue(path)
     translator.started.wait()
-    assert app_instance.db.all() == [(path, "nl")]
+    assert app_instance.db.all() == [(path, "nl", 0)]
 
     path.unlink()
     handler = SrtHandler(app_instance)


### PR DESCRIPTION
## Summary
- track priority in queue database and restore it on start
- preserve priority when enqueueing tasks
- test priority persistence across restarts

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a1e337b2c8832db0512785f574e545