### PR TITLE
fix: shorten info log paths

### DIFF
--- a/babelarr/app.py
+++ b/babelarr/app.py
@@ -218,7 +218,7 @@ class Application:
                     logger.info(
                         "Worker %s requeued %s to %s id=%s for later processing (queue length: %d)",
                         name,
-                        path,
+                        path.name,
                         lang,
                         task_id,
                         self.db.count(),
@@ -227,7 +227,7 @@ class Application:
                     self.db.remove(path, lang)
                     logger.info(
                         "translation %s to %s %s in %.2fs (queue length: %d)",
-                        path,
+                        path.name,
                         lang,
                         outcome,
                         elapsed,
@@ -323,7 +323,7 @@ class Application:
             task = TranslationTask(path, lang, uuid4().hex, priority)
             self.tasks.put((priority, self._task_counter, task))
             self._task_counter += 1
-            logger.info("restored %s to %s id=%s", path, lang, task.task_id)
+            logger.info("restored %s to %s id=%s", path.name, lang, task.task_id)
             self._ensure_workers()
 
     def watch(self):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -280,7 +280,8 @@ def test_translation_logs_summary_once(tmp_path, caplog, app):
     ]
     assert len(info_logs) == 1
     msg = info_logs[0].message
-    assert str(src) in msg
+    assert src.name in msg
+    assert str(src) not in msg
     assert "nl" in msg
     assert "succeeded" in msg
     assert re.search(r"in \d+\.\d+s", msg)


### PR DESCRIPTION
## Summary
- log only filename in info messages
- update translation log test for basename expectations

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a1ec64a100832dbe38ec32363a6bf9