### PR TITLE
fix: avoid persistent HTTP sessions

### DIFF
--- a/babelarr/cli.py
+++ b/babelarr/cli.py
@@ -129,6 +129,7 @@ def main(argv: list[str] | None = None) -> None:
         config.backoff_delay,
         config.availability_check_interval,
         api_key=config.api_key,
+        persistent_session=config.persistent_sessions,
     )
     filter_target_languages(config, translator)
     app = Application(config, translator)

--- a/babelarr/translator.py
+++ b/babelarr/translator.py
@@ -50,6 +50,7 @@ class LibreTranslateClient:
         backoff_delay: float = 1.0,
         availability_check_interval: float = 30.0,
         api_key: str | None = None,
+        persistent_session: bool = False,
     ) -> None:
         self.src_lang = src_lang
         self.retry_count = retry_count
@@ -57,7 +58,7 @@ class LibreTranslateClient:
         self.availability_check_interval = availability_check_interval
         self.api_key = api_key
 
-        self.api = LibreTranslateAPI(api_url)
+        self.api = LibreTranslateAPI(api_url, persistent_session=persistent_session)
         self.languages: dict[str, set[str]] | None = None
         self.supported_targets: set[str] | None = None
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -82,3 +82,9 @@ def test_invalid_scan_interval_falls_back_to_default(monkeypatch, caplog):
         cfg = Config.from_env()
     assert cfg.scan_interval_minutes == 60
     assert "Invalid SCAN_INTERVAL_MINUTES" in caplog.text
+
+
+def test_persistent_sessions_flag(monkeypatch):
+    monkeypatch.setenv("PERSISTENT_SESSIONS", "true")
+    cfg = Config.from_env()
+    assert cfg.persistent_sessions is True


### PR DESCRIPTION
## Summary
- create new requests connection for each LibreTranslate request by default
- add optional PERSISTENT_SESSIONS config flag and plumb through CLI
- cover connection handling with multi-thread tests

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a1f02e6370832daec327b0748aece7