### PR TITLE
refactor: use module-specific loggers

### DIFF
--- a/babelarr/app.py
+++ b/babelarr/app.py
@@ -16,7 +16,7 @@ from .config import Config
 from .queue_db import QueueRepository
 from .translator import Translator
 
-logger = logging.getLogger("babelarr")
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)

--- a/babelarr/cli.py
+++ b/babelarr/cli.py
@@ -11,7 +11,7 @@ from .config import Config
 from .queue_db import QueueRepository
 from .translator import LibreTranslateClient
 
-logger = logging.getLogger("babelarr")
+logger = logging.getLogger(__name__)
 
 
 def validate_environment(config: Config) -> None:
@@ -104,7 +104,7 @@ def main(argv: list[str] | None = None) -> None:
     logging.basicConfig(
         level=log_level,
         filename=log_file,
-        format="%(asctime)s [%(levelname)s] [%(threadName)s] %(message)s",
+        format="%(asctime)s [%(levelname)s] [%(name)s] [%(threadName)s] %(message)s",
     )
     logging.getLogger("watchdog").setLevel(logging.INFO)
     logging.getLogger("urllib3").setLevel(logging.WARNING)

--- a/babelarr/config.py
+++ b/babelarr/config.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-logger = logging.getLogger("babelarr")
+logger = logging.getLogger(__name__)
 
 
 @dataclass

--- a/babelarr/translator.py
+++ b/babelarr/translator.py
@@ -12,7 +12,7 @@ import requests
 
 from .libretranslate_api import LibreTranslateAPI
 
-logger = logging.getLogger("babelarr")
+logger = logging.getLogger(__name__)
 
 ERROR_MESSAGES = {
     400: "Bad Request",


### PR DESCRIPTION
## Summary
- use `logging.getLogger(__name__)` across babelarr modules
- add module names to CLI log format

## Testing
- `make setup`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a380fe9034832d8fd7afbf5121a2cf