### PR TITLE
fix: condense error response logging

### DIFF
--- a/babelarr/translator.py
+++ b/babelarr/translator.py
@@ -105,22 +105,27 @@ class LibreTranslateClient:
         if resp.status_code == 200:
             return
 
-        message = ERROR_MESSAGES.get(resp.status_code, "Unexpected error")
+        detail = ERROR_MESSAGES.get(resp.status_code, "Unexpected error")
         try:
             err_json = resp.json()
-            detail = (
+            extra = (
                 err_json.get("error")
                 or err_json.get("message")
                 or err_json.get("detail")
             )
-            if detail:
-                message = f"{message}: {detail}"
+            if extra:
+                detail = f"{detail}: {extra}"
         except ValueError:
             pass
 
-        logger.error("HTTP %s from %s: %s", resp.status_code, context, message)
-        logger.error("Headers: %s", resp.headers)
-        logger.error("Body: %s", resp.text)
+        logger.error(
+            "HTTP error from %s status=%s detail=%s headers=%s body=%s",
+            context,
+            resp.status_code,
+            detail,
+            resp.headers,
+            resp.text,
+        )
         if logger.isEnabledFor(logging.DEBUG):
             import tempfile
 

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -45,7 +45,12 @@ def test_translate_file_errors(tmp_path, status, caplog, app):
 
         def translate(self, path, lang):
             logger = logging.getLogger("babelarr")
-            logger.error("HTTP %s from LibreTranslate: boom", self.status_code)
+            logger.error(
+                "HTTP error from LibreTranslate status=%s detail=boom headers=%s body=%s",
+                self.status_code,
+                {},
+                "",
+            )
             resp = requests.Response()
             resp.status_code = self.status_code
             raise requests.HTTPError(response=resp)
@@ -55,7 +60,8 @@ def test_translate_file_errors(tmp_path, status, caplog, app):
     with caplog.at_level(logging.ERROR):
         with pytest.raises(requests.HTTPError):
             app_instance.translate_file(tmp_file, "nl")
-        assert str(status) in caplog.text
+        assert f"status={status}" in caplog.text
+        assert "detail=boom" in caplog.text
 
 
 def test_retry_success(monkeypatch, tmp_path, caplog):


### PR DESCRIPTION
## Summary
- log HTTP error responses in one structured line
- exercise condensed error logs in translator and app tests

## Testing
- `pre-commit run --all-files`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68a385876fec832dbdd43bdde76b5744