### PR TITLE
chore: install project in setup and tidy dev deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,9 @@ setup:
 	python -m pip install -U pip
 	@if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 	@if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+	pip install -e .
 	@which pre-commit >/dev/null 2>&1 || pip install pre-commit
-	pre-commit install --hook-type pre-commit --hook-type pre-push || true
+	pre-commit install --hook-type pre-commit --hook-type pre-push && echo "pre-commit hooks installed"
 
 lint:
 	pre-commit run --all-files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,9 @@ dependencies = [
 
 [project.scripts]
 babelarr = "babelarr.cli:main"
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "types-requests",
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,2 @@
 pytest
-requests
-watchdog
-schedule
 types-requests


### PR DESCRIPTION
## Summary
- install project in editable mode during `make setup`
- stop swallowing pre-commit installation errors and log success
- keep runtime deps out of dev requirements and expose `dev` extra

## Testing
- `make setup`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a3878e0c7c832d9f4ff1908258ea28