### PR TITLE
style: standardize logging messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,12 @@ When adding features, respect these boundaries. If cross-cutting concerns appear
 - Fail fast on unrecoverable errors; raise typed exceptions in library code. Handle at the edges (CLI/app) with clear messages.
 - Network interactions must use timeouts and retries with exponential backoff where appropriate (see `LibreTranslateClient`).
 
+### Logging conventions
+
+- Prefix messages with the module name (e.g., `app`, `cli`, `translator`).
+- Begin messages with a lowercase action verb.
+- Express context as `key=value` pairs.
+
 ---
 
 ## Testing rules
@@ -98,6 +104,7 @@ Codex (and humans) must ensure:
 - [ ] `make check` passes locally (setup → lint → tests).
 - [ ] New/changed behavior is covered by tests.
 - [ ] No debug prints; sensible logging only.
+- [ ] Log messages follow the logging conventions.
 - [ ] Public CLI behavior changes are documented in `README.md`.
 - [ ] No direct env reads or hidden globals; configuration goes through `Config`.
 - [ ] No secrets or credentials are committed.

--- a/babelarr/cli.py
+++ b/babelarr/cli.py
@@ -27,15 +27,15 @@ def validate_environment(config: Config) -> None:
     for d in config.root_dirs:
         path = Path(d)
         if not path.is_dir():
-            logger.warning("Watch directory %s does not exist; ignoring", d)
+            logger.warning("cli: missing_watch_dir path=%s", d)
             continue
         if not os.access(path, os.R_OK):
-            logger.warning("Watch directory %s is not readable; ignoring", d)
+            logger.warning("cli: unreadable_watch_dir path=%s", d)
             continue
         valid_dirs.append(d)
 
     if not valid_dirs:
-        logger.error("No readable watch directories found: %s", config.root_dirs)
+        logger.error("cli: no_readable_dirs dirs=%s", config.root_dirs)
         raise SystemExit("No valid watch directories configured")
 
     config.root_dirs = valid_dirs
@@ -45,9 +45,7 @@ def validate_environment(config: Config) -> None:
         if resp.status_code >= 400:
             raise requests.RequestException(f"HTTP {resp.status_code}")
     except requests.RequestException as exc:
-        logger.error(
-            "Translation service %s unreachable at startup: %s", config.api_url, exc
-        )
+        logger.error("cli: service_unreachable url=%s error=%s", config.api_url, exc)
 
 
 def filter_target_languages(config: Config, translator: LibreTranslateClient) -> None:
@@ -61,18 +59,17 @@ def filter_target_languages(config: Config, translator: LibreTranslateClient) ->
     try:
         translator.ensure_languages()
     except ValueError as exc:
-        logger.error("%s", exc)
+        logger.error("cli: language_error detail=%s", exc)
         raise SystemExit(str(exc))
     except requests.RequestException as exc:  # pragma: no cover - network failure
-        logger.error("Failed to fetch supported languages: %s", exc)
+        logger.error("cli: fetch_languages_failed error=%s", exc)
         return
 
     supported = translator.supported_targets or set()
     unsupported = [lang for lang in config.target_langs if lang not in supported]
     if unsupported:
         logger.warning(
-            "Ignoring unsupported target language%s: %s",
-            "s" if len(unsupported) > 1 else "",
+            "cli: unsupported_targets langs=%s",
             ", ".join(unsupported),
         )
         config.target_langs = [
@@ -80,7 +77,7 @@ def filter_target_languages(config: Config, translator: LibreTranslateClient) ->
         ]
 
     if not config.target_langs:
-        logger.error("No supported target languages configured")
+        logger.error("cli: no_supported_targets")
         raise SystemExit("No supported target languages configured")
 
 
@@ -135,7 +132,7 @@ def main(argv: list[str] | None = None) -> None:
     app = Application(config, translator)
 
     def handle_signal(signum, frame):
-        logger.info("Received signal %s", signum)
+        logger.info("cli: received_signal signum=%s", signum)
         app.shutdown_event.set()
 
     for sig in (signal.SIGINT, signal.SIGTERM):

--- a/babelarr/translator.py
+++ b/babelarr/translator.py
@@ -77,13 +77,11 @@ class LibreTranslateClient:
                 try:
                     self.ensure_languages()
                 except requests.RequestException as exc:
-                    logger.warning(
-                        "Failed to fetch languages from LibreTranslate: %s", exc
-                    )
+                    logger.warning("translator: fetch_languages_failed error=%s", exc)
                 else:
                     return
             logger.warning(
-                "LibreTranslate unreachable; retrying in %s seconds",
+                "translator: service_unreachable retry=%s",
                 self.availability_check_interval,
             )
             time.sleep(self.availability_check_interval)
@@ -119,7 +117,7 @@ class LibreTranslateClient:
             pass
 
         logger.error(
-            "HTTP error from %s status=%s detail=%s headers=%s body=%s",
+            "translator: http_error context=%s status=%s detail=%s headers=%s body=%s",
             context,
             resp.status_code,
             detail,
@@ -134,7 +132,7 @@ class LibreTranslateClient:
             )
             try:
                 tmp.write(resp.content)
-                logger.debug("Saved failing response to %s", tmp.name)
+                logger.debug("translator: save_error_response path=%s", tmp.name)
             finally:
                 tmp.close()
         resp.raise_for_status()
@@ -172,14 +170,14 @@ class LibreTranslateClient:
             except requests.RequestException as exc:
                 if attempt >= self.retry_count:
                     logger.error(
-                        "LibreTranslate request failed after %s attempts: %s",
+                        "translator: request_failed attempts=%s error=%s",
                         attempt,
                         exc,
                     )
                     raise
                 delay = self.backoff_delay * (2 ** (attempt - 1))
                 logger.warning(
-                    "Attempt %s failed: %s. Retrying in %s seconds",
+                    "translator: attempt_failed attempt=%s error=%s delay=%s",
                     attempt,
                     exc,
                     delay,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -182,7 +182,7 @@ def test_filter_target_languages_removes_unsupported(caplog):
     with caplog.at_level(logging.WARNING):
         cli.filter_target_languages(config, translator)
         assert config.target_langs == ["nl"]
-        assert "unsupported target" in caplog.text.lower()
+        assert "unsupported_targets" in caplog.text
 
 
 def test_filter_target_languages_exits_when_none_supported():

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -102,7 +102,7 @@ def test_retry_success(monkeypatch, tmp_path, caplog):
 
     assert result == b"ok"
     assert attempts["count"] == 3
-    retry_logs = [r for r in caplog.records if "Attempt" in r.message]
+    retry_logs = [r for r in caplog.records if "attempt_failed" in r.message]
     assert len(retry_logs) == 2
 
 
@@ -139,7 +139,7 @@ def test_retry_exhaustion(monkeypatch, tmp_path, caplog):
     translator.close()
 
     assert attempts["count"] == 2
-    assert "failed after 2 attempts" in caplog.text
+    assert "request_failed attempts=2" in caplog.text
 
 
 def test_api_key_included(monkeypatch, tmp_path):

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -116,7 +116,7 @@ def test_translate_error(monkeypatch, tmp_path, caplog):
     error_logs = [r for r in caplog.records if "status=400" in r.getMessage()]
     assert error_logs
     msg = error_logs[0].getMessage()
-    assert "HTTP error from LibreTranslate" in msg
+    assert "http_error context=LibreTranslate" in msg
     assert "status=400" in msg
     assert "detail=Bad Request: boom" in msg
     assert "headers={'X-Test': '1'}" in msg


### PR DESCRIPTION
## Summary
- document logging conventions in contributor guide
- align app, cli, and translator logs with the new style
- adjust tests for updated logging messages

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a387b2a82c832da8af6028b108b83f