### PR TITLE
refactor: drop module name prefixes from logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ When adding features, respect these boundaries. If cross-cutting concerns appear
 
 ### Logging conventions
 
-- Prefix messages with the module name (e.g., `app`, `cli`, `translator`).
+- Rely on the logger's name (`%(name)s`) for module context; do **not** repeat it in the message.
 - Begin messages with a lowercase action verb.
 - Express context as `key=value` pairs.
 

--- a/babelarr/cli.py
+++ b/babelarr/cli.py
@@ -27,15 +27,15 @@ def validate_environment(config: Config) -> None:
     for d in config.root_dirs:
         path = Path(d)
         if not path.is_dir():
-            logger.warning("cli: missing_watch_dir path=%s", d)
+            logger.warning("missing_watch_dir path=%s", d)
             continue
         if not os.access(path, os.R_OK):
-            logger.warning("cli: unreadable_watch_dir path=%s", d)
+            logger.warning("unreadable_watch_dir path=%s", d)
             continue
         valid_dirs.append(d)
 
     if not valid_dirs:
-        logger.error("cli: no_readable_dirs dirs=%s", config.root_dirs)
+        logger.error("no_readable_dirs dirs=%s", config.root_dirs)
         raise SystemExit("No valid watch directories configured")
 
     config.root_dirs = valid_dirs
@@ -45,7 +45,7 @@ def validate_environment(config: Config) -> None:
         if resp.status_code >= 400:
             raise requests.RequestException(f"HTTP {resp.status_code}")
     except requests.RequestException as exc:
-        logger.error("cli: service_unreachable url=%s error=%s", config.api_url, exc)
+        logger.error("service_unreachable url=%s error=%s", config.api_url, exc)
 
 
 def filter_target_languages(config: Config, translator: LibreTranslateClient) -> None:
@@ -59,17 +59,17 @@ def filter_target_languages(config: Config, translator: LibreTranslateClient) ->
     try:
         translator.ensure_languages()
     except ValueError as exc:
-        logger.error("cli: language_error detail=%s", exc)
+        logger.error("language_error detail=%s", exc)
         raise SystemExit(str(exc))
     except requests.RequestException as exc:  # pragma: no cover - network failure
-        logger.error("cli: fetch_languages_failed error=%s", exc)
+        logger.error("fetch_languages_failed error=%s", exc)
         return
 
     supported = translator.supported_targets or set()
     unsupported = [lang for lang in config.target_langs if lang not in supported]
     if unsupported:
         logger.warning(
-            "cli: unsupported_targets langs=%s",
+            "unsupported_targets langs=%s",
             ", ".join(unsupported),
         )
         config.target_langs = [
@@ -77,7 +77,7 @@ def filter_target_languages(config: Config, translator: LibreTranslateClient) ->
         ]
 
     if not config.target_langs:
-        logger.error("cli: no_supported_targets")
+        logger.error("no_supported_targets")
         raise SystemExit("No supported target languages configured")
 
 
@@ -132,7 +132,7 @@ def main(argv: list[str] | None = None) -> None:
     app = Application(config, translator)
 
     def handle_signal(signum, frame):
-        logger.info("cli: received_signal signum=%s", signum)
+        logger.info("received_signal signum=%s", signum)
         app.shutdown_event.set()
 
     for sig in (signal.SIGINT, signal.SIGTERM):

--- a/babelarr/translator.py
+++ b/babelarr/translator.py
@@ -77,11 +77,11 @@ class LibreTranslateClient:
                 try:
                     self.ensure_languages()
                 except requests.RequestException as exc:
-                    logger.warning("translator: fetch_languages_failed error=%s", exc)
+                    logger.warning("fetch_languages_failed error=%s", exc)
                 else:
                     return
             logger.warning(
-                "translator: service_unreachable retry=%s",
+                "service_unreachable retry=%s",
                 self.availability_check_interval,
             )
             time.sleep(self.availability_check_interval)
@@ -117,7 +117,7 @@ class LibreTranslateClient:
             pass
 
         logger.error(
-            "translator: http_error context=%s status=%s detail=%s headers=%s body=%s",
+            "http_error context=%s status=%s detail=%s headers=%s body=%s",
             context,
             resp.status_code,
             detail,
@@ -132,7 +132,7 @@ class LibreTranslateClient:
             )
             try:
                 tmp.write(resp.content)
-                logger.debug("translator: save_error_response path=%s", tmp.name)
+                logger.debug("save_error_response path=%s", tmp.name)
             finally:
                 tmp.close()
         resp.raise_for_status()
@@ -170,14 +170,14 @@ class LibreTranslateClient:
             except requests.RequestException as exc:
                 if attempt >= self.retry_count:
                     logger.error(
-                        "translator: request_failed attempts=%s error=%s",
+                        "request_failed attempts=%s error=%s",
                         attempt,
                         exc,
                     )
                     raise
                 delay = self.backoff_delay * (2 ** (attempt - 1))
                 logger.warning(
-                    "translator: attempt_failed attempt=%s error=%s delay=%s",
+                    "attempt_failed attempt=%s error=%s delay=%s",
                     attempt,
                     exc,
                     delay,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -43,7 +43,7 @@ def test_full_scan_logs_completion(tmp_path, caplog, app, monkeypatch):
     with caplog.at_level(logging.INFO):
         app_instance.full_scan()
 
-    assert "app: scan_complete files=2" in caplog.text
+    assert "scan_complete files=2" in caplog.text
 
 
 def test_request_scan_runs_on_scanner_thread(monkeypatch, app):
@@ -238,7 +238,7 @@ def test_worker_logs_processing_time(tmp_path, caplog, app):
 
     assert any(
         rec.levelno == logging.DEBUG
-        and rec.message.startswith("app: worker_finish")
+        and rec.message.startswith("worker_finish")
         and f"path={src}" in rec.message
         and "lang=nl" in rec.message
         and "task_id=" in rec.message
@@ -262,7 +262,7 @@ def test_worker_translating_logged_as_debug(tmp_path, caplog, app):
 
     assert any(
         rec.levelno == logging.DEBUG
-        and rec.message.startswith("app: worker_translate")
+        and rec.message.startswith("worker_translate")
         and "name=worker_0" in rec.message
         for rec in caplog.records
     )
@@ -289,7 +289,7 @@ def test_translation_logs_summary_once(tmp_path, caplog, app):
     info_logs = [
         rec
         for rec in caplog.records
-        if rec.levelno == logging.INFO and rec.message.startswith("app: translation ")
+        if rec.levelno == logging.INFO and rec.message.startswith("translation ")
     ]
     assert len(info_logs) == 1
     msg = info_logs[0].message


### PR DESCRIPTION
## Summary
- remove explicit `app:`, `cli:` and `translator:` prefixes from log messages
- update `TranslationLogger` calls and tests for new log format
- document logging guidelines to rely on logger names instead of manual prefixes

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68a38c6622e8832daab02ce3e0e0458d