### PR TITLE
feat: log cli startup and environment state

### DIFF
--- a/babelarr/cli.py
+++ b/babelarr/cli.py
@@ -39,6 +39,7 @@ def validate_environment(config: Config) -> None:
         raise SystemExit("No valid watch directories configured")
 
     config.root_dirs = valid_dirs
+    logger.info("cli: environment_ready dirs=%s", valid_dirs)
 
     try:
         resp = requests.head(config.api_url, timeout=900)
@@ -76,6 +77,7 @@ def filter_target_languages(config: Config, translator: LibreTranslateClient) ->
             lang for lang in config.target_langs if lang in supported
         ]
 
+    logger.info("cli: target_langs langs=%s", ", ".join(config.target_langs))
     if not config.target_langs:
         logger.error("no_supported_targets")
         raise SystemExit("No supported target languages configured")
@@ -105,6 +107,7 @@ def main(argv: list[str] | None = None) -> None:
     )
     logging.getLogger("watchdog").setLevel(logging.INFO)
     logging.getLogger("urllib3").setLevel(logging.WARNING)
+    logger.info("cli: start log_level=%s log_file=%s", log_level, log_file)
 
     if args.command == "queue":
         config = Config.from_env()
@@ -119,6 +122,11 @@ def main(argv: list[str] | None = None) -> None:
 
     config = Config.from_env()
     validate_environment(config)
+    logger.info(
+        "cli: config_loaded api_url=%s targets=%s",
+        config.api_url,
+        config.target_langs,
+    )
     translator = LibreTranslateClient(
         config.api_url,
         config.src_lang,


### PR DESCRIPTION
## Summary
- log start parameters, environment readiness, loaded config, and target languages
- test new CLI logging behaviors

## Testing
- `make setup`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a3945d2c5c832d8d6d4bbd2c3d4e43