### PR TITLE
feat: log translator availability

### DIFF
--- a/babelarr/translator.py
+++ b/babelarr/translator.py
@@ -79,6 +79,7 @@ class LibreTranslateClient:
                 except requests.RequestException as exc:
                     logger.warning("fetch_languages_failed error=%s", exc)
                 else:
+                    logger.info("translator: service_available")
                     return
             logger.warning(
                 "service_unreachable retry=%s",
@@ -97,6 +98,10 @@ class LibreTranslateClient:
         if self.src_lang not in self.languages:
             raise ValueError(f"Unsupported source language: {self.src_lang}")
         self.supported_targets = self.languages[self.src_lang]
+        logger.info(
+            "translator: languages_loaded count=%d",
+            len(self.supported_targets),
+        )
 
     def _handle_error_response(self, resp: requests.Response, context: str) -> None:
         """Log and raise for non-200 *resp* responses."""

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -149,3 +149,26 @@ def test_translate_download(monkeypatch, tmp_path):
     client.close()
 
     assert result == b"translated"
+
+
+def test_ensure_languages_logs_count(monkeypatch, caplog):
+    client = LibreTranslateClient("http://example", "en")
+    monkeypatch.setattr(
+        client.api,
+        "fetch_languages",
+        lambda: [{"code": "en", "targets": ["nl", "es"]}],
+    )
+    with caplog.at_level(logging.INFO):
+        client.ensure_languages()
+    assert "translator: languages_loaded count=2" in caplog.text
+
+
+def test_wait_until_available_logs_service_available(monkeypatch, caplog):
+    client = LibreTranslateClient(
+        "http://example", "en", availability_check_interval=0.1
+    )
+    monkeypatch.setattr(client, "is_available", lambda: True)
+    monkeypatch.setattr(client, "ensure_languages", lambda: None)
+    with caplog.at_level(logging.INFO):
+        client.wait_until_available()
+    assert "translator: service_available" in caplog.text


### PR DESCRIPTION
## Summary
- log when translation service becomes available
- report number of languages loaded
- add tests for new translator logs

## Testing
- `make setup`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a394628f50832d8d9693ffd7926960