### PR TITLE
fix: log configuration at info level

### DIFF
--- a/babelarr/config.py
+++ b/babelarr/config.py
@@ -182,11 +182,11 @@ class Config:
         scan_interval_minutes = parsed["SCAN_INTERVAL_MINUTES"]
         persistent_sessions = parsed["PERSISTENT_SESSIONS"]
 
-        logger.debug(
-            "Config: ROOT_DIRS=%s TARGET_LANGS=%s SRC_LANG=%s API_URL=%s "
-            "WORKERS=%s QUEUE_DB=%s API_KEY_SET=%s RETRY_COUNT=%s "
-            "BACKOFF_DELAY=%s AVAILABILITY_CHECK_INTERVAL=%s DEBOUNCE=%s SCAN_INTERVAL_MINUTES=%s "
-            "PERSISTENT_SESSIONS=%s",
+        logger.info(
+            "loaded config root_dirs=%s target_langs=%s src_lang=%s api_url=%s "
+            "workers=%s queue_db=%s api_key_set=%s retry_count=%s "
+            "backoff_delay=%s availability_check_interval=%s debounce=%s scan_interval_minutes=%s "
+            "persistent_sessions=%s",
             root_dirs,
             target_langs,
             src_lang,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,13 +92,13 @@ def test_main_sets_urllib3_logger_to_warning(monkeypatch):
     assert logging.getLogger("urllib3").level == logging.WARNING
 
 
-def test_log_level_debug_enables_debug_output(tmp_path, monkeypatch, capsys):
+def test_log_level_debug_logs_configuration(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("QUEUE_DB", str(tmp_path / "queue.db"))
     logging.getLogger().handlers.clear()
     logging.getLogger().setLevel(logging.NOTSET)
     cli.main(["--log-level", "DEBUG", "queue"])
     captured = capsys.readouterr()
-    assert "Config:" in captured.err
+    assert "loaded config" in captured.err
 
 
 def test_log_file_option_creates_file(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- log configuration details at info level using key=value pairs
- adjust CLI test for new configuration log

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a3946ddf48832da19686d998c8b520