### PR TITLE
refactor: log file names instead of full paths

### DIFF
--- a/babelarr/cli.py
+++ b/babelarr/cli.py
@@ -27,19 +27,24 @@ def validate_environment(config: Config) -> None:
     for d in config.root_dirs:
         path = Path(d)
         if not path.is_dir():
-            logger.warning("missing_watch_dir path=%s", d)
+            logger.warning("missing_watch_dir path=%s", path.name)
             continue
         if not os.access(path, os.R_OK):
-            logger.warning("unreadable_watch_dir path=%s", d)
+            logger.warning("unreadable_watch_dir path=%s", path.name)
             continue
         valid_dirs.append(d)
 
     if not valid_dirs:
-        logger.error("no_readable_dirs dirs=%s", config.root_dirs)
+        logger.error(
+            "no_readable_dirs dirs=%s", [Path(d).name for d in config.root_dirs]
+        )
         raise SystemExit("No valid watch directories configured")
 
     config.root_dirs = valid_dirs
-    logger.info("cli: environment_ready dirs=%s", valid_dirs)
+    logger.info(
+        "cli: environment_ready dirs=%s",
+        [Path(d).name for d in valid_dirs],
+    )
 
     try:
         resp = requests.head(config.api_url, timeout=900)

--- a/babelarr/translator.py
+++ b/babelarr/translator.py
@@ -137,7 +137,7 @@ class LibreTranslateClient:
             )
             try:
                 tmp.write(resp.content)
-                logger.debug("save_error_response path=%s", tmp.name)
+                logger.debug("save_error_response path=%s", Path(tmp.name).name)
             finally:
                 tmp.close()
         resp.raise_for_status()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -204,7 +204,7 @@ def test_queue_length_logging(tmp_path, monkeypatch, app, config, caplog):
         queued_logs = [r for r in caplog.records if r.levelno == logging.INFO]
         assert any("queue=1" in r.message for r in queued_logs)
         assert any(
-            f"path={sub_file}" in r.message
+            f"path={sub_file.name}" in r.message
             and "lang=nl" in r.message
             and "task_id=" in r.message
             for r in queued_logs
@@ -218,7 +218,7 @@ def test_queue_length_logging(tmp_path, monkeypatch, app, config, caplog):
 
         done_logs = [r for r in caplog.records if "queue=0" in r.message]
         assert any(
-            f"path={sub_file}" in r.message and "lang=nl" in r.message
+            f"path={sub_file.name}" in r.message and "lang=nl" in r.message
             for r in done_logs
         )
     assert app_instance.db.all() == []
@@ -272,7 +272,7 @@ def test_worker_logs_processing_time(tmp_path, caplog, app):
     assert any(
         rec.levelno == logging.DEBUG
         and rec.message.startswith("worker_finish")
-        and f"path={src}" in rec.message
+        and f"path={src.name}" in rec.message
         and "lang=nl" in rec.message
         and "task_id=" in rec.message
         for rec in caplog.records
@@ -326,7 +326,7 @@ def test_translation_logs_summary_once(tmp_path, caplog, app):
     ]
     assert len(info_logs) == 1
     msg = info_logs[0].message
-    assert f"path={src}" in msg
+    assert f"path={src.name}" in msg
     assert "lang=nl" in msg
     assert "task_id=" in msg
     assert "outcome=succeeded" in msg

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -279,4 +279,4 @@ def test_watch_missing_directory(monkeypatch, tmp_path, app, caplog):
         app_instance.watch()
 
     assert events["scheduled"] == [str(existing)]
-    assert str(missing) in caplog.text
+    assert missing.name in caplog.text


### PR DESCRIPTION
## Summary
- shorten logged paths to only include file names
- adjust CLI and watcher logs to drop directory info
- update tests for new logging format

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a409bc2820832d9091c021e005df54