### PR TITLE
chore: use venv in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,23 @@
+
+VENV ?= .venv
+
 .PHONY: setup lint test check
 
 setup:
-	python -m pip install -U pip
-	@if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-	@if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
-	pip install -e .
-	@which pre-commit >/dev/null 2>&1 || pip install pre-commit
-	pre-commit install --hook-type pre-commit --hook-type pre-push && echo "pre-commit hooks installed"
+	@if [ ! -d "$(VENV)" ]; then python -m venv $(VENV); fi
+	$(VENV)/bin/pip install -U pip
+	@if [ -f requirements.txt ]; then $(VENV)/bin/pip install -r requirements.txt; fi
+	@if [ -f requirements-dev.txt ]; then $(VENV)/bin/pip install -r requirements-dev.txt; fi
+	$(VENV)/bin/pip install -e .
+	@which $(VENV)/bin/pre-commit >/dev/null 2>&1 || $(VENV)/bin/pip install pre-commit
+	$(VENV)/bin/pre-commit install --hook-type pre-commit --hook-type pre-push && echo "pre-commit hooks installed"
 
 lint:
-	pre-commit run --all-files
+	$(VENV)/bin/pre-commit run --all-files
 
 test:
-	pytest --maxfail=1 --disable-warnings -q
+	$(VENV)/bin/pytest --maxfail=1 --disable-warnings -q
 
-check: setup lint test
+check: setup
+	$(VENV)/bin/pre-commit run --all-files
+	$(VENV)/bin/pytest --maxfail=1 --disable-warnings -q


### PR DESCRIPTION
## Summary
- add VENV variable and use venv binaries in Makefile

## Testing
- `make lint`
- `make test`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68a40c3796a8832d95804ee97bbec6f8