### PR TITLE
refactor: split worker and watcher into dedicated modules

### DIFF
--- a/babelarr/__init__.py
+++ b/babelarr/__init__.py
@@ -1,14 +1,17 @@
 """Babelarr package."""
 
-from .app import Application, SrtHandler
+from .app import Application
 from .config import Config
 from .queue_db import QueueRepository
 from .translator import LibreTranslateClient, Translator
+from .watch import SrtHandler
+from .worker import TranslationTask
 
 __all__ = [
     "Config",
     "Application",
     "SrtHandler",
+    "TranslationTask",
     "QueueRepository",
     "Translator",
     "LibreTranslateClient",

--- a/babelarr/watch.py
+++ b/babelarr/watch.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from watchdog.events import PatternMatchingEventHandler
+from watchdog.observers import Observer
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .app import Application
+
+
+class SrtHandler(PatternMatchingEventHandler):
+    def __init__(self, app: Application):
+        self.app = app
+        self._debounce = self.app.config.debounce
+        self._max_wait = 30
+        self._recent: dict[Path, float] = {}
+        super().__init__(
+            patterns=[f"*{self.app.config.src_ext}"],
+            ignore_directories=True,
+        )
+
+    def _wait_for_complete(self, path: Path) -> bool:
+        """Wait until *path* appears stable before enqueueing.
+
+        Returns ``False`` if the file disappears while waiting or the timeout
+        is exceeded.
+        """
+        start = time.monotonic()
+        while True:
+            try:
+                size = path.stat().st_size
+            except FileNotFoundError:
+                return False
+            time.sleep(self._debounce)
+            try:
+                new_size = path.stat().st_size
+            except FileNotFoundError:
+                return False
+            if new_size == size:
+                return True
+            if time.monotonic() - start > self._max_wait:
+                logger.warning("timeout_stabilize path=%s", path.name)
+                return False
+
+    def _handle(self, path: Path) -> None:
+        now = time.monotonic()
+        # prune expired entries
+        for p, ts in list(self._recent.items()):
+            if now - ts > self._debounce:
+                del self._recent[p]
+
+        last = self._recent.get(path)
+        if last and now - last < self._debounce:
+            logger.debug("skip_recent path=%s age=%.2fs", path.name, now - last)
+            return
+
+        if self._wait_for_complete(path):
+            self._recent[path] = now
+            self.app.enqueue(path)
+
+    def on_created(self, event):
+        logger.debug("detect_new path=%s", Path(event.src_path).name)
+        self._handle(Path(event.src_path))
+
+    def on_deleted(self, event):
+        logger.debug("detect_deleted path=%s", Path(event.src_path).name)
+        self.app.db.remove(Path(event.src_path))
+
+    def on_modified(self, event):
+        """Ignore file modification events."""
+        return
+
+    def on_moved(self, event):
+        dest = Path(event.dest_path)
+        logger.debug(
+            "detect_move src=%s dest=%s",
+            Path(event.src_path).name,
+            dest.name,
+        )
+        self._handle(dest)
+
+
+def watch(app: Application) -> None:
+    observer = Observer()
+    for root in app.config.root_dirs:
+        logger.debug("watch path=%s", Path(root).name)
+        root_path = Path(root)
+        if not root_path.exists():
+            logger.warning("missing_directory path=%s", root_path.name)
+            continue
+        observer.schedule(SrtHandler(app), root, recursive=True)
+    observer.start()
+    logger.info("observer_started")
+    try:
+        while not app.shutdown_event.is_set():
+            time.sleep(1)
+    finally:
+        observer.stop()
+        observer.join()
+        logger.info("observer_stopped")

--- a/babelarr/worker.py
+++ b/babelarr/worker.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import logging
+import queue
+import threading
+import time
+from collections.abc import Callable, Mapping, MutableMapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .app import Application
+
+
+class TranslationLogger(logging.LoggerAdapter):
+    """Logger adapter that appends translation context."""
+
+    def __init__(
+        self,
+        path: Path | None = None,
+        lang: str | None = None,
+        task_id: str | None = None,
+    ) -> None:
+        path_name = None
+        if isinstance(path, (str, Path)):
+            path_name = Path(path).name
+        extra = {"path": path_name, "lang": lang, "task_id": task_id}
+        super().__init__(logger, extra)
+
+    def process(
+        self, msg: str, kwargs: MutableMapping[str, Any]
+    ) -> tuple[str, MutableMapping[str, Any]]:
+        source = self.extra or {}
+        extra: dict[str, Any] = {k: v for k, v in source.items() if v is not None}
+        supplied = kwargs.get("extra")
+        if isinstance(supplied, Mapping):
+            for k, v in supplied.items():
+                if v is not None:
+                    extra[k] = v
+        path_val = extra.get("path")
+        if isinstance(path_val, Path):
+            extra["path"] = path_val.name
+        elif isinstance(path_val, str):
+            extra["path"] = Path(path_val).name
+        kwargs["extra"] = extra
+        if extra:
+            msg = f"{msg} " + " ".join(f"{k}={v}" for k, v in extra.items())
+        return msg, kwargs
+
+
+@dataclass(frozen=True)
+class TranslationTask:
+    path: Path
+    lang: str
+    task_id: str
+    priority: int = 0
+
+
+def get_task(app: Application) -> TranslationTask | None:
+    try:
+        _, _, task = app.tasks.get(timeout=0.1)
+        return task
+    except queue.Empty:
+        return None
+
+
+def process_translation(
+    app: Application, task: TranslationTask, worker_name: str
+) -> bool:
+    path, lang, task_id = task.path, task.lang, task.task_id
+    tlog = TranslationLogger(path, lang, task_id)
+    if path.exists():
+        tlog.debug("worker_translate name=%s", worker_name)
+        return app.translate_file(path, lang, task_id)
+    tlog.warning("worker_missing name=%s", worker_name)
+    return False
+
+
+def handle_failure(
+    app: Application,
+    task: TranslationTask,
+    exc: Exception,
+    worker_name: str,
+    wait: Callable[[], None] | None,
+) -> bool:
+    path, lang, task_id = task.path, task.lang, task.task_id
+    tlog = TranslationLogger(path, lang, task_id)
+    tlog.error("translation_failed name=%s error=%s", worker_name, exc)
+    tlog.debug("traceback", exc_info=True)
+    if isinstance(exc, requests.RequestException):
+        app.translator_available.clear()
+        if callable(wait):
+            wait()
+        app.translator_available.set()
+        return True
+    return False
+
+
+def worker(app: Application) -> None:
+    name = threading.current_thread().name
+    logger.debug("worker_start name=%s", name)
+    wait = getattr(app.translator, "wait_until_available", None)
+    if callable(wait):
+        wait()
+    app.translator_available.set()
+    try:
+        while not app.shutdown_event.is_set():
+            if not app.translator_available.wait(timeout=1):
+                continue
+            task = get_task(app)
+            if task is None:
+                break
+            path, lang, task_id = task.path, task.lang, task.task_id
+            tlog = TranslationLogger(path, lang, task_id)
+            start_time = time.monotonic()
+            tlog.debug("worker_pickup name=%s", name)
+            try:
+                success = process_translation(app, task, name)
+                requeue = False
+                outcome = "succeeded" if success else "skipped"
+            except Exception as exc:  # noqa: BLE001
+                requeue = handle_failure(app, task, exc, name, wait)
+                success = False
+                outcome = "failed"
+            elapsed = time.monotonic() - start_time
+            if requeue:
+                app.tasks.put((task.priority, app._task_counter, task))
+                app._task_counter += 1
+                tlog.info(
+                    "worker_requeue name=%s queue=%d",
+                    name,
+                    app.db.count(),
+                )
+            else:
+                app.db.remove(path, lang)
+                tlog.info(
+                    "translation outcome=%s duration=%.2fs queue=%d",
+                    outcome,
+                    elapsed,
+                    app.db.count(),
+                )
+            app.tasks.task_done()
+            tlog.debug(
+                "worker_finish name=%s duration=%.2fs",
+                name,
+                elapsed,
+            )
+    finally:
+        with app._worker_lock:
+            app._active_workers -= 1
+            app._worker_threads.discard(threading.current_thread())
+            logger.info(
+                "worker_exit name=%s active=%d",
+                name,
+                app._active_workers,
+            )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,4 @@
 import logging
-import queue
-import re
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -8,8 +6,8 @@ from pathlib import Path
 import pytest
 import requests
 
+import babelarr.worker as worker_module
 from babelarr import cli
-from babelarr.app import TranslationTask
 from babelarr.config import Config
 
 
@@ -91,7 +89,7 @@ def test_scan_tasks_lower_priority_than_watcher(tmp_path, app, monkeypatch):
     instance.enqueue(watch_file)
 
     with ThreadPoolExecutor(max_workers=1) as executor:
-        executor.submit(instance.worker)
+        executor.submit(worker_module.worker, instance)
         instance.tasks.join()
         instance.shutdown_event.set()
 
@@ -112,7 +110,7 @@ def test_db_persistence_across_restarts(tmp_path, app):
     assert app2.tasks.queue[0][0] == 5
 
     with ThreadPoolExecutor(max_workers=1) as executor:
-        executor.submit(app2.worker)
+        executor.submit(worker_module.worker, app2)
         app2.tasks.join()
         app2.shutdown_event.set()
 
@@ -150,221 +148,6 @@ def test_load_pending_logs_summary(tmp_path, caplog, app):
         if rec.levelno == logging.DEBUG and rec.message.startswith("restored ")
     ]
     assert len(debug_restored) == 2
-
-
-def test_worker_retry_on_network_failure(tmp_path, caplog, app):
-    src = tmp_path / "fail.en.srt"
-    src.write_text("hello")
-
-    class UnstableTranslator:
-        def __init__(self):
-            self.attempts = 0
-
-        def translate(self, path, lang):
-            self.attempts += 1
-            if self.attempts == 1:
-                raise requests.ConnectionError("boom")
-            return b"ok"
-
-        def wait_until_available(self):
-            return None
-
-    translator = UnstableTranslator()
-    app_instance = app(translator=translator)
-
-    with ThreadPoolExecutor(max_workers=1) as executor:
-        executor.submit(app_instance.worker)
-
-        with caplog.at_level(logging.ERROR):
-            app_instance.enqueue(src)
-            app_instance.tasks.join()
-            assert any("translation_failed" in r.message for r in caplog.records)
-
-        app_instance.shutdown_event.set()
-
-    assert app_instance.output_path(src, "nl").exists()
-
-
-def test_queue_length_logging(tmp_path, monkeypatch, app, config, caplog):
-    sub_file = tmp_path / "video.en.srt"
-    sub_file.write_text("1\n00:00:00,000 --> 00:00:02,000\nHello\n")
-
-    config.src_ext = ".srt"
-    app_instance = app(cfg=config)
-
-    def fake_translate_file(src, lang, task_id=None):
-        app_instance.output_path(src, lang).write_text("Hallo")
-        return True
-
-    monkeypatch.setattr(app_instance, "translate_file", fake_translate_file)
-    monkeypatch.setattr(app_instance, "_ensure_workers", lambda: None)
-
-    with caplog.at_level(logging.INFO):
-        app_instance.enqueue(sub_file)
-        queued_logs = [r for r in caplog.records if r.levelno == logging.INFO]
-        assert any("queue=1" in r.message for r in queued_logs)
-        assert any(
-            f"path={sub_file.name}" in r.message
-            and "lang=nl" in r.message
-            and "task_id=" in r.message
-            for r in queued_logs
-        )
-        caplog.clear()
-
-        with ThreadPoolExecutor(max_workers=1) as executor:
-            executor.submit(app_instance.worker)
-            app_instance.tasks.join()
-            app_instance.shutdown_event.set()
-
-        done_logs = [r for r in caplog.records if "queue=0" in r.message]
-        assert any(
-            f"path={sub_file.name}" in r.message and "lang=nl" in r.message
-            for r in done_logs
-        )
-    assert app_instance.db.all() == []
-
-
-def test_worker_skips_output_if_source_deleted(tmp_path, caplog, app):
-    src = tmp_path / "gone.en.srt"
-    src.write_text("hello")
-
-    class DeletingTranslator:
-        def translate(self, path, lang):
-            path.unlink()
-            return b"ok"
-
-        def wait_until_available(self):
-            return None
-
-    translator = DeletingTranslator()
-    app_instance = app(translator=translator)
-
-    with ThreadPoolExecutor(max_workers=1) as executor:
-        executor.submit(app_instance.worker)
-
-        with caplog.at_level(logging.INFO):
-            app_instance.enqueue(src)
-            app_instance.tasks.join()
-            assert "reason=source_missing" in caplog.text
-            assert "outcome=skipped" in caplog.text
-            assert "succeeded" not in caplog.text
-
-        app_instance.shutdown_event.set()
-
-    assert not app_instance.output_path(src, "nl").exists()
-    assert app_instance.db.all() == []
-
-
-def test_worker_logs_processing_time(tmp_path, caplog, app):
-    src = tmp_path / "video.en.srt"
-    src.write_text("hello")
-
-    app_instance = app()
-
-    with ThreadPoolExecutor(max_workers=1) as executor:
-        executor.submit(app_instance.worker)
-
-        with caplog.at_level(logging.DEBUG):
-            app_instance.enqueue(src)
-            app_instance.tasks.join()
-            app_instance.shutdown_event.set()
-
-    assert any(
-        rec.levelno == logging.DEBUG
-        and rec.message.startswith("worker_finish")
-        and f"path={src.name}" in rec.message
-        and "lang=nl" in rec.message
-        and "task_id=" in rec.message
-        for rec in caplog.records
-    )
-
-
-def test_worker_translating_logged_as_debug(tmp_path, caplog, app):
-    src = tmp_path / "video.en.srt"
-    src.write_text("hello")
-
-    app_instance = app()
-
-    with ThreadPoolExecutor(max_workers=1, thread_name_prefix="worker") as executor:
-        executor.submit(app_instance.worker)
-
-        with caplog.at_level(logging.DEBUG):
-            app_instance.enqueue(src)
-            app_instance.tasks.join()
-            app_instance.shutdown_event.set()
-
-    assert any(
-        rec.levelno == logging.DEBUG
-        and rec.message.startswith("worker_translate")
-        and "name=worker_0" in rec.message
-        for rec in caplog.records
-    )
-    assert not any(
-        rec.levelno == logging.INFO and "worker_translate" in rec.message
-        for rec in caplog.records
-    )
-
-
-def test_translation_logs_summary_once(tmp_path, caplog, app):
-    src = tmp_path / "video.en.srt"
-    src.write_text("hello")
-
-    app_instance = app()
-
-    with ThreadPoolExecutor(max_workers=1) as executor:
-        executor.submit(app_instance.worker)
-
-        with caplog.at_level(logging.INFO):
-            app_instance.enqueue(src)
-            app_instance.tasks.join()
-            app_instance.shutdown_event.set()
-
-    info_logs = [
-        rec
-        for rec in caplog.records
-        if rec.levelno == logging.INFO and rec.message.startswith("translation ")
-    ]
-    assert len(info_logs) == 1
-    msg = info_logs[0].message
-    assert f"path={src.name}" in msg
-    assert "lang=nl" in msg
-    assert "task_id=" in msg
-    assert "outcome=succeeded" in msg
-    assert re.search(r"duration=\d+\.\d+s", msg)
-
-
-def test_workers_wait_when_translator_unavailable(tmp_path, app):
-    src = tmp_path / "fail.en.srt"
-    src.write_text("hello")
-
-    class FlakyTranslator:
-        def __init__(self):
-            self.calls = 0
-            self.wait_calls = 0
-
-        def translate(self, path, lang):
-            self.calls += 1
-            if self.calls == 1:
-                raise requests.ConnectionError("boom")
-            assert self.wait_calls >= 2
-            return b"ok"
-
-        def wait_until_available(self):
-            self.wait_calls += 1
-            return None
-
-    translator = FlakyTranslator()
-    app_instance = app(translator=translator)
-
-    with ThreadPoolExecutor(max_workers=1) as executor:
-        executor.submit(app_instance.worker)
-        app_instance.enqueue(src)
-        app_instance.tasks.join()
-        app_instance.shutdown_event.set()
-
-    assert translator.calls == 2
-    assert translator.wait_calls >= 2
-    assert app_instance.output_path(src, "nl").exists()
 
 
 def test_validate_environment_no_valid_dirs(tmp_path, monkeypatch):
@@ -420,7 +203,7 @@ def test_configurable_scan_interval(monkeypatch, config, app):
         return Job()
 
     monkeypatch.setattr(app_mod.schedule, "every", fake_every)
-    monkeypatch.setattr(instance, "watch", lambda: None)
+    monkeypatch.setattr(app_mod.watch_module, "watch", lambda _app: None)
     monkeypatch.setattr(instance, "scan_worker", lambda: None)
     instance.shutdown_event.set()
     instance.run()
@@ -428,36 +211,6 @@ def test_configurable_scan_interval(monkeypatch, config, app):
     assert called["interval"] == 5
     assert called["func"].__self__ is instance
     assert called["func"].__func__ is instance.request_scan.__func__
-
-
-def test_worker_wait_called_once(app):
-    calls = {"count": 0}
-
-    class Translator:
-        def __init__(self):
-            self.called = threading.Event()
-
-        def wait_until_available(self):
-            calls["count"] += 1
-            self.called.set()
-
-        def translate(self, path, lang):
-            return b""
-
-    translator = Translator()
-    instance = app(translator=translator)
-
-    def fast_get(timeout=1):
-        raise queue.Empty
-
-    instance.tasks.get = fast_get
-
-    thread = threading.Thread(target=instance.worker)
-    thread.start()
-    assert translator.called.wait(timeout=1)
-    thread.join(timeout=1)
-
-    assert calls["count"] == 1
 
 
 def test_workers_spawn_and_exit(tmp_path, app, caplog):
@@ -492,45 +245,3 @@ def test_workers_spawn_and_exit(tmp_path, app, caplog):
         t.join(timeout=1)
 
     assert instance._active_workers == 0
-
-
-def test_get_task_returns_task_or_none(tmp_path, app):
-    instance = app()
-    task = TranslationTask(tmp_path / "video.en.srt", "nl", "1")
-    instance.tasks.put((task.priority, instance._task_counter, task))
-    instance._task_counter += 1
-    assert instance._get_task() == task
-    assert instance._get_task() is None
-
-
-def test_process_translation_missing_file(tmp_path, caplog, app):
-    instance = app()
-    task = TranslationTask(tmp_path / "missing.en.srt", "nl", "1")
-    with caplog.at_level(logging.WARNING):
-        result = instance._process_translation(task, "worker")
-    assert result is False
-    assert "missing" in caplog.text
-
-
-def test_handle_failure_requeues_on_request_exception(app):
-    instance = app()
-    task = TranslationTask(Path("a"), "nl", "1")
-    calls = []
-
-    def fake_wait():
-        calls.append(1)
-
-    instance.translator_available.set()
-    requeue = instance._handle_failure(
-        task, requests.RequestException("boom"), "worker", fake_wait
-    )
-    assert requeue is True
-    assert calls == [1]
-
-
-def test_handle_failure_generic_exception(app):
-    instance = app()
-    task = TranslationTask(Path("a"), "nl", "1")
-    instance.translator_available.set()
-    requeue = instance._handle_failure(task, RuntimeError("boom"), "worker", None)
-    assert requeue is False

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,5 +1,7 @@
 from concurrent.futures import ThreadPoolExecutor
 
+import babelarr.worker as worker_module
+
 
 def test_enqueue_and_worker(tmp_path, monkeypatch, app, config):
     sub_file = tmp_path / "video.en.srt"
@@ -16,7 +18,7 @@ def test_enqueue_and_worker(tmp_path, monkeypatch, app, config):
 
     app_instance.enqueue(sub_file)
     with ThreadPoolExecutor(max_workers=1) as executor:
-        executor.submit(app_instance.worker)
+        executor.submit(worker_module.worker, app_instance)
         app_instance.tasks.join()
         app_instance.shutdown_event.set()
 
@@ -40,7 +42,7 @@ def test_enqueue_uppercase_extension(tmp_path, monkeypatch, app, config):
 
     app_instance.enqueue(sub_file)
     with ThreadPoolExecutor(max_workers=1) as executor:
-        executor.submit(app_instance.worker)
+        executor.submit(worker_module.worker, app_instance)
         app_instance.tasks.join()
         app_instance.shutdown_event.set()
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,0 +1,299 @@
+import logging
+import queue
+import re
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import requests
+
+import babelarr.worker as worker_module
+from babelarr.worker import TranslationTask
+
+
+def test_worker_retry_on_network_failure(tmp_path, caplog, app):
+    src = tmp_path / "fail.en.srt"
+    src.write_text("hello")
+
+    class UnstableTranslator:
+        def __init__(self):
+            self.attempts = 0
+
+        def translate(self, path, lang):
+            self.attempts += 1
+            if self.attempts == 1:
+                raise requests.ConnectionError("boom")
+            return b"ok"
+
+        def wait_until_available(self):
+            return None
+
+    translator = UnstableTranslator()
+    app_instance = app(translator=translator)
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        executor.submit(worker_module.worker, app_instance)
+
+        with caplog.at_level(logging.ERROR):
+            app_instance.enqueue(src)
+            app_instance.tasks.join()
+            assert any("translation_failed" in r.message for r in caplog.records)
+
+        app_instance.shutdown_event.set()
+
+    assert app_instance.output_path(src, "nl").exists()
+
+
+def test_queue_length_logging(tmp_path, monkeypatch, app, config, caplog):
+    sub_file = tmp_path / "video.en.srt"
+    sub_file.write_text("1\n00:00:00,000 --> 00:00:02,000\nHello\n")
+
+    config.src_ext = ".srt"
+    app_instance = app(cfg=config)
+
+    def fake_translate_file(src, lang, task_id=None):
+        app_instance.output_path(src, lang).write_text("Hallo")
+        return True
+
+    monkeypatch.setattr(app_instance, "translate_file", fake_translate_file)
+    monkeypatch.setattr(app_instance, "_ensure_workers", lambda: None)
+
+    with caplog.at_level(logging.INFO):
+        app_instance.enqueue(sub_file)
+        queued_logs = [r for r in caplog.records if r.levelno == logging.INFO]
+        assert any("queue=1" in r.message for r in queued_logs)
+        assert any(
+            f"path={sub_file.name}" in r.message
+            and "lang=nl" in r.message
+            and "task_id=" in r.message
+            for r in queued_logs
+        )
+        caplog.clear()
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            executor.submit(worker_module.worker, app_instance)
+            app_instance.tasks.join()
+            app_instance.shutdown_event.set()
+
+        done_logs = [r for r in caplog.records if "queue=0" in r.message]
+        assert any(
+            f"path={sub_file.name}" in r.message and "lang=nl" in r.message
+            for r in done_logs
+        )
+    assert app_instance.db.all() == []
+
+
+def test_worker_skips_output_if_source_deleted(tmp_path, caplog, app):
+    src = tmp_path / "gone.en.srt"
+    src.write_text("hello")
+
+    class DeletingTranslator:
+        def translate(self, path, lang):
+            path.unlink()
+            return b"ok"
+
+        def wait_until_available(self):
+            return None
+
+    translator = DeletingTranslator()
+    app_instance = app(translator=translator)
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        executor.submit(worker_module.worker, app_instance)
+
+        with caplog.at_level(logging.INFO):
+            app_instance.enqueue(src)
+            app_instance.tasks.join()
+            app_instance.shutdown_event.set()
+            assert "reason=source_missing" in caplog.text
+            assert "outcome=skipped" in caplog.text
+            assert "succeeded" not in caplog.text
+
+    assert not app_instance.output_path(src, "nl").exists()
+    assert app_instance.db.all() == []
+
+
+def test_worker_logs_processing_time(tmp_path, caplog, app):
+    src = tmp_path / "video.en.srt"
+    src.write_text("hello")
+
+    app_instance = app()
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        executor.submit(worker_module.worker, app_instance)
+
+        with caplog.at_level(logging.DEBUG):
+            app_instance.enqueue(src)
+            app_instance.tasks.join()
+            app_instance.shutdown_event.set()
+
+    assert any(
+        rec.levelno == logging.DEBUG
+        and rec.message.startswith("worker_finish")
+        and f"path={src.name}" in rec.message
+        and "lang=nl" in rec.message
+        and "task_id=" in rec.message
+        for rec in caplog.records
+    )
+
+
+def test_worker_translating_logged_as_debug(tmp_path, caplog, app):
+    src = tmp_path / "video.en.srt"
+    src.write_text("hello")
+
+    app_instance = app()
+
+    with ThreadPoolExecutor(max_workers=1, thread_name_prefix="worker") as executor:
+        executor.submit(worker_module.worker, app_instance)
+
+        with caplog.at_level(logging.DEBUG):
+            app_instance.enqueue(src)
+            app_instance.tasks.join()
+            app_instance.shutdown_event.set()
+
+    assert any(
+        rec.levelno == logging.DEBUG
+        and rec.message.startswith("worker_translate")
+        and "name=worker_0" in rec.message
+        for rec in caplog.records
+    )
+    assert not any(
+        rec.levelno == logging.INFO and "worker_translate" in rec.message
+        for rec in caplog.records
+    )
+
+
+def test_translation_logs_summary_once(tmp_path, caplog, app):
+    src = tmp_path / "video.en.srt"
+    src.write_text("hello")
+
+    app_instance = app()
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        executor.submit(worker_module.worker, app_instance)
+
+        with caplog.at_level(logging.INFO):
+            app_instance.enqueue(src)
+            app_instance.tasks.join()
+            app_instance.shutdown_event.set()
+
+    info_logs = [
+        rec
+        for rec in caplog.records
+        if rec.levelno == logging.INFO and rec.message.startswith("translation ")
+    ]
+    assert len(info_logs) == 1
+    msg = info_logs[0].message
+    assert f"path={src.name}" in msg
+    assert "lang=nl" in msg
+    assert "task_id=" in msg
+    assert "outcome=succeeded" in msg
+    assert re.search(r"duration=\d+\.\d+s", msg)
+
+
+def test_workers_wait_when_translator_unavailable(tmp_path, app):
+    src = tmp_path / "fail.en.srt"
+    src.write_text("hello")
+
+    class FlakyTranslator:
+        def __init__(self):
+            self.calls = 0
+            self.wait_calls = 0
+
+        def translate(self, path, lang):
+            self.calls += 1
+            if self.calls == 1:
+                raise requests.ConnectionError("boom")
+            assert self.wait_calls >= 2
+            return b"ok"
+
+        def wait_until_available(self):
+            self.wait_calls += 1
+            return None
+
+    translator = FlakyTranslator()
+    app_instance = app(translator=translator)
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        executor.submit(worker_module.worker, app_instance)
+        app_instance.enqueue(src)
+        app_instance.tasks.join()
+        app_instance.shutdown_event.set()
+
+    assert translator.calls == 2
+    assert translator.wait_calls >= 2
+    assert app_instance.output_path(src, "nl").exists()
+
+
+def test_worker_wait_called_once(app):
+    calls = {"count": 0}
+
+    class Translator:
+        def __init__(self):
+            self.called = threading.Event()
+
+        def wait_until_available(self):
+            calls["count"] += 1
+            self.called.set()
+
+        def translate(self, path, lang):
+            return b""
+
+    translator = Translator()
+    instance = app(translator=translator)
+
+    def fast_get(timeout=1):
+        raise queue.Empty
+
+    instance.tasks.get = fast_get
+
+    thread = threading.Thread(target=worker_module.worker, args=(instance,))
+    thread.start()
+    assert translator.called.wait(timeout=1)
+    thread.join(timeout=1)
+
+    assert calls["count"] == 1
+
+
+def test_get_task_returns_task_or_none(tmp_path, app):
+    instance = app()
+    task = TranslationTask(tmp_path / "video.en.srt", "nl", "1")
+    instance.tasks.put((task.priority, instance._task_counter, task))
+    instance._task_counter += 1
+    assert worker_module.get_task(instance) == task
+    assert worker_module.get_task(instance) is None
+
+
+def test_process_translation_missing_file(tmp_path, caplog, app):
+    instance = app()
+    task = TranslationTask(tmp_path / "missing.en.srt", "nl", "1")
+    with caplog.at_level(logging.WARNING):
+        result = worker_module.process_translation(instance, task, "worker")
+    assert result is False
+    assert "missing" in caplog.text
+
+
+def test_handle_failure_requeues_on_request_exception(app):
+    instance = app()
+    task = TranslationTask(Path("a"), "nl", "1")
+    calls = []
+
+    def fake_wait():
+        calls.append(1)
+
+    instance.translator_available.set()
+    requeue = worker_module.handle_failure(
+        instance, task, requests.RequestException("boom"), "worker", fake_wait
+    )
+    assert requeue is True
+    assert calls == [1]
+
+
+def test_handle_failure_generic_exception(app):
+    instance = app()
+    task = TranslationTask(Path("a"), "nl", "1")
+    instance.translator_available.set()
+    requeue = worker_module.handle_failure(
+        instance, task, RuntimeError("boom"), "worker", None
+    )
+    assert requeue is False


### PR DESCRIPTION
## Summary
- extract translation task logic into new `worker` module
- move SRT handler and observer setup into `watch` module
- streamline application orchestration and update tests for new structure

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a412bbaf78832db657a421d29d2239