### PR TITLE
test: mark integration tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
-addopts = --assert=plain --strict-markers --strict-config
+addopts = --assert=plain --strict-markers --strict-config -m "not integration"
+markers =
+    integration: tests requiring external services or slow operations

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -2,6 +2,7 @@ import logging
 import threading
 from pathlib import Path
 
+import pytest
 from watchdog.events import (
     FileCreatedEvent,
     FileDeletedEvent,
@@ -12,6 +13,8 @@ from watchdog.events import (
 import babelarr.watch as watch_module
 from babelarr.config import Config
 from babelarr.watch import SrtHandler
+
+pytestmark = pytest.mark.integration
 
 
 def test_srt_handler_patterns(app):

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -5,10 +5,13 @@ import threading
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
+import pytest
 import requests
 
 import babelarr.worker as worker_module
 from babelarr.worker import TranslationTask
+
+pytestmark = pytest.mark.integration
 
 
 def test_worker_retry_on_network_failure(tmp_path, caplog, app):


### PR DESCRIPTION
## Summary
- add `integration` marker to pytest configuration and exclude integration tests from default runs
- mark watcher and worker tests as integration

## Testing
- `pytest --markers | head -n 20`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a4d1fb7d3c832daa83877731910691