### PR TITLE
feat: add Jellyfin integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ docker run -d --name babelarr \
 | `SRC_LANG` | `en` | Two-letter source language of existing subtitles; files matching `*.LANG.srt` are processed. |
 | `LIBRETRANSLATE_URL` | `http://libretranslate:5000` | Base URL of the LibreTranslate instance (no path). |
 | `LIBRETRANSLATE_API_KEY` | *(unset)* | API key for authenticated LibreTranslate instances. |
+| `JELLYFIN_URL` | *(unset)* | Base URL of the Jellyfin server for library refreshes. |
+| `JELLYFIN_TOKEN` | *(unset)* | API token for Jellyfin requests. |
 | `LOG_LEVEL` | `INFO` | Controls verbosity of console output. |
 | `LOG_FILE` | *(unset)* | If set, writes logs to the specified file. |
 | `WORKERS` | `1` | Number of translation worker threads (maximum 10). |

--- a/babelarr/cli.py
+++ b/babelarr/cli.py
@@ -8,6 +8,7 @@ import requests
 
 from .app import Application
 from .config import Config
+from .jellyfin_api import JellyfinClient
 from .queue_db import QueueRepository
 from .translator import LibreTranslateClient
 
@@ -142,7 +143,10 @@ def main(argv: list[str] | None = None) -> None:
         persistent_session=config.persistent_sessions,
     )
     filter_target_languages(config, translator)
-    app = Application(config, translator)
+    jellyfin_client = None
+    if config.jellyfin_url and config.jellyfin_token:
+        jellyfin_client = JellyfinClient(config.jellyfin_url, config.jellyfin_token)
+    app = Application(config, translator, jellyfin_client)
 
     def handle_signal(signum, frame):
         logger.info("received_signal signum=%s", signum)

--- a/babelarr/config.py
+++ b/babelarr/config.py
@@ -21,6 +21,8 @@ class Config:
         workers: Number of translation worker threads.
         queue_db: Path to the SQLite queue database.
         api_key: Optional API key for authenticated requests.
+        jellyfin_url: Base URL of the Jellyfin server.
+        jellyfin_token: API token for Jellyfin.
         retry_count: Translation retry attempts.
         backoff_delay: Initial backoff delay between retries.
         debounce: Seconds to wait for file changes to settle before enqueueing.
@@ -35,6 +37,8 @@ class Config:
     workers: int
     queue_db: str
     api_key: str | None = None
+    jellyfin_url: str | None = None
+    jellyfin_token: str | None = None
     retry_count: int = 3
     backoff_delay: float = 1.0
     availability_check_interval: float = 30.0
@@ -153,6 +157,8 @@ class Config:
         queue_db = str(queue_db_path)
 
         api_key = os.environ.get("LIBRETRANSLATE_API_KEY") or None
+        jellyfin_url = os.environ.get("JELLYFIN_URL") or None
+        jellyfin_token = os.environ.get("JELLYFIN_TOKEN") or None
 
         parsers: dict[str, Callable[[str | None], Any]] = {
             "TARGET_LANGS": cls._parse_target_languages,
@@ -184,8 +190,8 @@ class Config:
 
         logger.info(
             "loaded config root_dirs=%s target_langs=%s src_lang=%s api_url=%s "
-            "workers=%s queue_db=%s api_key_set=%s retry_count=%s "
-            "backoff_delay=%s availability_check_interval=%s debounce=%s scan_interval_minutes=%s "
+            "workers=%s queue_db=%s api_key_set=%s jellyfin_url=%s jellyfin_token_set=%s "
+            "retry_count=%s backoff_delay=%s availability_check_interval=%s debounce=%s scan_interval_minutes=%s "
             "persistent_sessions=%s",
             root_dirs,
             target_langs,
@@ -194,6 +200,8 @@ class Config:
             workers,
             queue_db,
             bool(api_key),
+            jellyfin_url,
+            bool(jellyfin_token),
             retry_count,
             backoff_delay,
             availability_check_interval,
@@ -211,6 +219,8 @@ class Config:
             workers=workers,
             queue_db=queue_db,
             api_key=api_key,
+            jellyfin_url=jellyfin_url,
+            jellyfin_token=jellyfin_token,
             retry_count=retry_count,
             backoff_delay=backoff_delay,
             availability_check_interval=availability_check_interval,

--- a/babelarr/jellyfin_api.py
+++ b/babelarr/jellyfin_api.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import requests
+
+
+class JellyfinClient:
+    """Minimal client for Jellyfin refresh API."""
+
+    def __init__(self, base_url: str, token: str) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+
+    def refresh_path(self, path: Path) -> None:
+        """Notify Jellyfin that *path* has been updated."""
+
+        url = self.base_url + "/Library/Media/Updated"
+        payload = {"Updates": [{"Path": str(path)}]}
+        headers = {"X-Emby-Token": self.token}
+        resp = requests.post(url, json=payload, headers=headers, timeout=900)
+        resp.raise_for_status()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,10 +34,10 @@ def config(tmp_path):
 def app(config):
     instances = []
 
-    def _create_app(*, translator=None, cfg=None):
+    def _create_app(*, translator=None, cfg=None, jellyfin=None):
         cfg = cfg or config
         translator = translator or _DummyTranslator()
-        instance = Application(cfg, translator)
+        instance = Application(cfg, translator, jellyfin)
         instances.append(instance)
         return instance
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -245,3 +245,19 @@ def test_workers_spawn_and_exit(tmp_path, app, caplog):
         t.join(timeout=1)
 
     assert instance._active_workers == 0
+
+
+def test_translate_file_refreshes_jellyfin(tmp_path, app):
+    src = tmp_path / "video.en.srt"
+    src.write_text("hello")
+
+    called: list[Path] = []
+
+    class DummyJellyfin:
+        def refresh_path(self, path: Path) -> None:
+            called.append(path)
+
+    instance = app(jellyfin=DummyJellyfin())
+    instance.translate_file(src, "nl")
+
+    assert called == [instance.output_path(src, "nl")]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -88,3 +88,21 @@ def test_persistent_sessions_flag(monkeypatch):
     monkeypatch.setenv("PERSISTENT_SESSIONS", "true")
     cfg = Config.from_env()
     assert cfg.persistent_sessions is True
+
+
+def test_jellyfin_env_parsed(monkeypatch, tmp_path):
+    monkeypatch.setenv("QUEUE_DB", str(tmp_path / "queue.db"))
+    monkeypatch.setenv("JELLYFIN_URL", "http://jf")
+    monkeypatch.setenv("JELLYFIN_TOKEN", "abc")
+    cfg = Config.from_env()
+    assert cfg.jellyfin_url == "http://jf"
+    assert cfg.jellyfin_token == "abc"
+
+
+def test_jellyfin_defaults(monkeypatch, tmp_path):
+    monkeypatch.setenv("QUEUE_DB", str(tmp_path / "queue.db"))
+    monkeypatch.delenv("JELLYFIN_URL", raising=False)
+    monkeypatch.delenv("JELLYFIN_TOKEN", raising=False)
+    cfg = Config.from_env()
+    assert cfg.jellyfin_url is None
+    assert cfg.jellyfin_token is None

--- a/tests/test_jellyfin_api.py
+++ b/tests/test_jellyfin_api.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+import requests
+
+from babelarr.jellyfin_api import JellyfinClient
+
+
+def test_refresh_path(monkeypatch):
+    calls: dict[str, object] = {}
+
+    def fake_post(url, *, json=None, headers=None, timeout=900):
+        calls["url"] = url
+        calls["json"] = json
+        calls["headers"] = headers
+        resp = requests.Response()
+        resp.status_code = 204
+        return resp
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    client = JellyfinClient("http://jf", "tok")
+    client.refresh_path(Path("/data/file.srt"))
+
+    assert calls["url"] == "http://jf/Library/Media/Updated"
+    assert calls["json"] == {"Updates": [{"Path": "/data/file.srt"}]}
+    assert calls["headers"] == {"X-Emby-Token": "tok"}


### PR DESCRIPTION
## Summary
- add optional Jellyfin URL and token settings
- refresh Jellyfin library path after writing translated subtitles
- document Jellyfin configuration variables

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a4d93c406c832d975b8abab8d00d50