### PR TITLE
feat: refresh source when translations complete

### DIFF
--- a/babelarr/worker.py
+++ b/babelarr/worker.py
@@ -138,6 +138,8 @@ def worker(app: Application) -> None:
                 )
             else:
                 app.db.remove(path, lang)
+                if app.jellyfin:
+                    app.translation_done(path, lang)
                 tlog.info(
                     "translation outcome=%s duration=%.2fs queue=%d",
                     outcome,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -30,6 +30,15 @@ def test_full_scan(tmp_path, monkeypatch, app):
     assert sorted(called) == sorted([first, second])
 
 
+def test_enqueue_tracks_pending_languages(tmp_path, app, monkeypatch):
+    src = tmp_path / "video.en.srt"
+    src.write_text("hello")
+    instance = app()
+    monkeypatch.setattr(instance, "_ensure_workers", lambda: None)
+    instance.enqueue(src)
+    assert instance.pending_translations[src] == {"nl"}
+
+
 def test_full_scan_logs_completion(tmp_path, caplog, app, monkeypatch):
     first = tmp_path / "one.en.srt"
     first.write_text("a")


### PR DESCRIPTION
## Summary
- track pending subtitle translations per source
- refresh base media path after all language translations finish
- cover pending tracking and Jellyfin refresh with unit tests

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a4dc907fac832dba67dc4bf63f077b