### PR TITLE
fix: refresh Jellyfin after all translations

### DIFF
--- a/babelarr/app.py
+++ b/babelarr/app.py
@@ -75,11 +75,6 @@ class Application:
         output = self.output_path(src, lang)
         output.write_bytes(content)
         tlog.debug("save output=%s", output.name)
-        if self.jellyfin:
-            try:
-                self.jellyfin.refresh_path(output)
-            except Exception as exc:  # noqa: BLE001
-                tlog.error("jellyfin_refresh_failed error=%s", exc)
         return True
 
     def needs_translation(self, path: Path, lang: str) -> bool:
@@ -102,7 +97,8 @@ class Application:
             del self.pending_translations[path]
         if self.jellyfin:
             try:
-                self.jellyfin.refresh_path(path.with_suffix(""))
+                stem = path.name.removesuffix(self.config.src_ext)
+                self.jellyfin.refresh_path(path.with_name(stem))
             except Exception as exc:  # noqa: BLE001
                 TranslationLogger(path, lang).error(
                     "jellyfin_refresh_failed error=%s", exc

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -256,17 +256,17 @@ def test_workers_spawn_and_exit(tmp_path, app, caplog):
     assert instance._active_workers == 0
 
 
-def test_translate_file_refreshes_jellyfin(tmp_path, app):
+def test_translate_file_does_not_refresh_jellyfin(tmp_path, app):
     src = tmp_path / "video.en.srt"
     src.write_text("hello")
 
     called: list[Path] = []
 
     class DummyJellyfin:
-        def refresh_path(self, path: Path) -> None:
+        def refresh_path(self, path: Path) -> None:  # pragma: no cover - trivial
             called.append(path)
 
     instance = app(jellyfin=DummyJellyfin())
     instance.translate_file(src, "nl")
 
-    assert called == [instance.output_path(src, "nl")]
+    assert called == []

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -83,8 +83,9 @@ def test_refresh_base_path_after_all_translations(tmp_path, app, monkeypatch):
     out_nl = instance.output_path(src, "nl")
     out_fr = instance.output_path(src, "fr")
     calls = instance.jellyfin.calls
-    assert calls[-1] == src.with_suffix("")
-    assert set(calls[:-1]) == {out_nl, out_fr}
+    expected = src.with_name(src.name.removesuffix(cfg.src_ext))
+    assert calls == [expected]
+    assert out_nl not in calls and out_fr not in calls
     assert instance.pending_translations == {}
 
 


### PR DESCRIPTION
## Summary
- avoid Jellyfin rescans for each subtitle translation
- refresh Jellyfin once using the base media path after all translations finish
- test Jellyfin refresh occurs only once per media file

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a4d5d6cc28832d9fcfb457872bb7e8