### PR TITLE
feat: add configurable timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ docker run -d --name babelarr \
 | `DEBOUNCE_SECONDS` | `0.1` | Wait time to ensure files have finished writing before enqueueing. |
 | `SCAN_INTERVAL_MINUTES` | `60` | Minutes between full directory scans. |
 | `AVAILABILITY_CHECK_INTERVAL` | `30` | Seconds between checks for LibreTranslate availability. |
+| `HTTP_TIMEOUT` | `10` | Timeout in seconds for non-translation HTTP requests. |
+| `TRANSLATION_TIMEOUT` | `900` | Timeout in seconds for translation requests. |
 | `QUEUE_DB` | `/config/queue.db` | Path to the SQLite queue database. |
 
 If `TARGET_LANGS` is empty or only contains invalid entries, the application raises a `ValueError` during startup.

--- a/babelarr/cli.py
+++ b/babelarr/cli.py
@@ -48,7 +48,7 @@ def validate_environment(config: Config) -> None:
     )
 
     try:
-        resp = requests.head(config.api_url, timeout=900)
+        resp = requests.head(config.api_url, timeout=config.http_timeout)
         if resp.status_code >= 400:
             raise requests.RequestException(f"HTTP {resp.status_code}")
     except requests.RequestException as exc:
@@ -141,11 +141,15 @@ def main(argv: list[str] | None = None) -> None:
         config.availability_check_interval,
         api_key=config.api_key,
         persistent_session=config.persistent_sessions,
+        http_timeout=config.http_timeout,
+        translation_timeout=config.translation_timeout,
     )
     filter_target_languages(config, translator)
     jellyfin_client = None
     if config.jellyfin_url and config.jellyfin_token:
-        jellyfin_client = JellyfinClient(config.jellyfin_url, config.jellyfin_token)
+        jellyfin_client = JellyfinClient(
+            config.jellyfin_url, config.jellyfin_token, config.http_timeout
+        )
     app = Application(config, translator, jellyfin_client)
 
     def handle_signal(signum, frame):

--- a/babelarr/config.py
+++ b/babelarr/config.py
@@ -44,6 +44,8 @@ class Config:
     availability_check_interval: float = 30.0
     debounce: float = 0.1
     scan_interval_minutes: int = 60
+    http_timeout: float = 10.0
+    translation_timeout: float = 900.0
     persistent_sessions: bool = False
 
     @staticmethod
@@ -170,6 +172,10 @@ class Config:
             ),
             "DEBOUNCE_SECONDS": lambda v: cls._parse_float("DEBOUNCE_SECONDS", v, 0.1),
             "SCAN_INTERVAL_MINUTES": cls._parse_scan_interval,
+            "HTTP_TIMEOUT": lambda v: cls._parse_float("HTTP_TIMEOUT", v, 10.0),
+            "TRANSLATION_TIMEOUT": lambda v: cls._parse_float(
+                "TRANSLATION_TIMEOUT", v, 900.0
+            ),
             "PERSISTENT_SESSIONS": lambda v: cls._parse_bool(
                 "PERSISTENT_SESSIONS", v, False
             ),
@@ -186,13 +192,15 @@ class Config:
         availability_check_interval = parsed["AVAILABILITY_CHECK_INTERVAL"]
         debounce = parsed["DEBOUNCE_SECONDS"]
         scan_interval_minutes = parsed["SCAN_INTERVAL_MINUTES"]
+        http_timeout = parsed["HTTP_TIMEOUT"]
+        translation_timeout = parsed["TRANSLATION_TIMEOUT"]
         persistent_sessions = parsed["PERSISTENT_SESSIONS"]
 
         logger.info(
             "loaded config root_dirs=%s target_langs=%s src_lang=%s api_url=%s "
             "workers=%s queue_db=%s api_key_set=%s jellyfin_url=%s jellyfin_token_set=%s "
             "retry_count=%s backoff_delay=%s availability_check_interval=%s debounce=%s scan_interval_minutes=%s "
-            "persistent_sessions=%s",
+            "persistent_sessions=%s http_timeout=%s translation_timeout=%s",
             root_dirs,
             target_langs,
             src_lang,
@@ -208,6 +216,8 @@ class Config:
             debounce,
             scan_interval_minutes,
             persistent_sessions,
+            http_timeout,
+            translation_timeout,
         )
 
         return cls(
@@ -226,5 +236,7 @@ class Config:
             availability_check_interval=availability_check_interval,
             debounce=debounce,
             scan_interval_minutes=scan_interval_minutes,
+            http_timeout=http_timeout,
+            translation_timeout=translation_timeout,
             persistent_sessions=persistent_sessions,
         )

--- a/babelarr/jellyfin_api.py
+++ b/babelarr/jellyfin_api.py
@@ -8,9 +8,10 @@ import requests
 class JellyfinClient:
     """Minimal client for Jellyfin refresh API."""
 
-    def __init__(self, base_url: str, token: str) -> None:
+    def __init__(self, base_url: str, token: str, timeout: float = 10.0) -> None:
         self.base_url = base_url.rstrip("/")
         self.token = token
+        self.timeout = timeout
 
     def refresh_path(self, path: Path) -> None:
         """Notify Jellyfin that *path* has been updated."""
@@ -18,5 +19,5 @@ class JellyfinClient:
         url = self.base_url + "/Library/Media/Updated"
         payload = {"Updates": [{"Path": str(path)}]}
         headers = {"X-Emby-Token": self.token}
-        resp = requests.post(url, json=payload, headers=headers, timeout=900)
+        resp = requests.post(url, json=payload, headers=headers, timeout=self.timeout)
         resp.raise_for_status()

--- a/babelarr/translator.py
+++ b/babelarr/translator.py
@@ -51,6 +51,8 @@ class LibreTranslateClient:
         availability_check_interval: float = 30.0,
         api_key: str | None = None,
         persistent_session: bool = False,
+        http_timeout: float = 10.0,
+        translation_timeout: float = 900.0,
     ) -> None:
         self.src_lang = src_lang
         self.retry_count = retry_count
@@ -58,14 +60,21 @@ class LibreTranslateClient:
         self.availability_check_interval = availability_check_interval
         self.api_key = api_key
 
-        self.api = LibreTranslateAPI(api_url, persistent_session=persistent_session)
+        self.api = LibreTranslateAPI(
+            api_url,
+            http_timeout=http_timeout,
+            translation_timeout=translation_timeout,
+            persistent_session=persistent_session,
+        )
         self.languages: dict[str, set[str]] | None = None
         self.supported_targets: set[str] | None = None
 
     def is_available(self) -> bool:
         """Return ``True`` if the service responds without error."""
         try:
-            resp = self.api.session.head(self.api.base_url, timeout=900)
+            resp = self.api.session.head(
+                self.api.base_url, timeout=self.api.http_timeout
+            )
             return resp.status_code < 400
         except requests.RequestException:
             return False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -213,7 +213,11 @@ def test_validate_environment_logs_environment_ready(tmp_path, monkeypatch, capl
     class DummyResp:
         status_code = 200
 
-    monkeypatch.setattr(cli.requests, "head", lambda url, timeout: DummyResp())
+    def fake_head(url, *, timeout):
+        assert timeout == 10
+        return DummyResp()
+
+    monkeypatch.setattr(cli.requests, "head", fake_head)
 
     with caplog.at_level(logging.INFO):
         cli.validate_environment(config)

--- a/tests/test_jellyfin_api.py
+++ b/tests/test_jellyfin_api.py
@@ -8,10 +8,11 @@ from babelarr.jellyfin_api import JellyfinClient
 def test_refresh_path(monkeypatch):
     calls: dict[str, object] = {}
 
-    def fake_post(url, *, json=None, headers=None, timeout=900):
+    def fake_post(url, *, json=None, headers=None, timeout):
         calls["url"] = url
         calls["json"] = json
         calls["headers"] = headers
+        calls["timeout"] = timeout
         resp = requests.Response()
         resp.status_code = 204
         return resp
@@ -24,3 +25,4 @@ def test_refresh_path(monkeypatch):
     assert calls["url"] == "http://jf/Library/Media/Updated"
     assert calls["json"] == {"Updates": [{"Path": "/data/file.srt"}]}
     assert calls["headers"] == {"X-Emby-Token": "tok"}
+    assert calls["timeout"] == 10

--- a/tests/test_libretranslate_api.py
+++ b/tests/test_libretranslate_api.py
@@ -7,9 +7,9 @@ from babelarr.libretranslate_api import LibreTranslateAPI
 
 
 def test_fetch_languages(monkeypatch):
-    def fake_get(self, url, *, timeout=900):
+    def fake_get(self, url, *, timeout):
         assert url == "http://only/languages"
-        assert timeout == 900
+        assert timeout == 10
         resp = requests.Response()
         resp.status_code = 200
         resp._content = b"[]"
@@ -26,8 +26,8 @@ def test_fetch_languages(monkeypatch):
 
 
 def test_fetch_languages_error(monkeypatch):
-    def fake_get(self, url, *, timeout=900):
-        assert timeout == 900
+    def fake_get(self, url, *, timeout):
+        assert timeout == 10
         raise requests.ConnectionError("boom")
 
     monkeypatch.setattr(requests.Session, "get", fake_get)
@@ -44,7 +44,7 @@ def test_translate_file_error(monkeypatch, tmp_path):
     tmp_file = tmp_path / "a.srt"
     tmp_file.write_text("dummy")
 
-    def fake_post(url, *, files=None, data=None, timeout=900, headers=None):
+    def fake_post(url, *, files=None, data=None, timeout, headers=None):
         assert timeout == 900
         raise requests.ConnectionError("fail")
 
@@ -94,7 +94,8 @@ def test_translate_file(monkeypatch, tmp_path):
 def test_download_uses_connection_close(monkeypatch):
     calls: list[dict | None] = []
 
-    def fake_get(url, *, timeout=900, headers=None):
+    def fake_get(url, *, timeout, headers=None):
+        assert timeout == 10
         calls.append(headers)
         resp = requests.Response()
         resp.status_code = 200
@@ -117,7 +118,8 @@ def test_translate_file_persistent_session(monkeypatch, tmp_path):
 
     sessions = []
 
-    def fake_post(self, url, *, files=None, data=None, timeout=900, headers=None):
+    def fake_post(self, url, *, files=None, data=None, timeout, headers=None):
+        assert timeout == 900
         sessions.append(id(self))
         resp = requests.Response()
         resp.status_code = 200

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -79,8 +79,8 @@ def test_retry_success(monkeypatch, tmp_path, caplog):
         resp._content = b"ok"
         return resp
 
-    def fake_get(self, url, *, timeout=900):
-        assert timeout == 900
+    def fake_get(self, url, *, timeout):
+        assert timeout == 10
         resp = requests.Response()
         resp.status_code = 200
         resp._content = (
@@ -116,8 +116,8 @@ def test_retry_exhaustion(monkeypatch, tmp_path, caplog):
         attempts["count"] += 1
         raise requests.ConnectionError("boom")
 
-    def fake_get(self, url, *, timeout=900):
-        assert timeout == 900
+    def fake_get(self, url, *, timeout):
+        assert timeout == 10
         resp = requests.Response()
         resp.status_code = 200
         resp._content = (
@@ -148,7 +148,7 @@ def test_api_key_included(monkeypatch, tmp_path):
 
     captured: dict[str, dict | None] = {"data": None}
 
-    def fake_post(url, *, files=None, data=None, timeout=900, headers=None):
+    def fake_post(url, *, files=None, data=None, timeout, headers=None):
         assert timeout == 900
         captured["data"] = data
         resp = requests.Response()
@@ -156,8 +156,8 @@ def test_api_key_included(monkeypatch, tmp_path):
         resp._content = b"ok"
         return resp
 
-    def fake_get(self, url, *, timeout=900):
-        assert timeout == 900
+    def fake_get(self, url, *, timeout):
+        assert timeout == 10
         resp = requests.Response()
         resp.status_code = 200
         resp._content = (
@@ -190,7 +190,7 @@ def test_src_lang_included(monkeypatch, tmp_path):
 
     captured: dict[str, dict | None] = {"data": None}
 
-    def fake_post(url, *, files=None, data=None, timeout=900, headers=None):
+    def fake_post(url, *, files=None, data=None, timeout, headers=None):
         assert timeout == 900
         captured["data"] = data
         resp = requests.Response()
@@ -198,8 +198,8 @@ def test_src_lang_included(monkeypatch, tmp_path):
         resp._content = b"ok"
         return resp
 
-    def fake_get(self, url, *, timeout=900):
-        assert timeout == 900
+    def fake_get(self, url, *, timeout):
+        assert timeout == 10
         resp = requests.Response()
         resp.status_code = 200
         resp._content = (
@@ -229,7 +229,7 @@ def test_download_translated_file(monkeypatch, tmp_path):
     tmp_file = tmp_path / "sample.en.srt"
     tmp_file.write_text("1\n00:00:00,000 --> 00:00:02,000\nHello\n")
 
-    def fake_post(url, *, files=None, data=None, timeout=900, headers=None):
+    def fake_post(url, *, files=None, data=None, timeout, headers=None):
         assert timeout == 900
         resp = requests.Response()
         resp.status_code = 200
@@ -239,8 +239,8 @@ def test_download_translated_file(monkeypatch, tmp_path):
     downloaded = {"url": None}
     calls: list[tuple[str, int]] = []
 
-    def fake_get_session(self, url, *, timeout=900):
-        assert timeout == 900
+    def fake_get_session(self, url, *, timeout):
+        assert timeout == 10
         calls.append((url, timeout))
         resp = requests.Response()
         resp.status_code = 200
@@ -250,8 +250,8 @@ def test_download_translated_file(monkeypatch, tmp_path):
         )
         return resp
 
-    def fake_get(url, *, timeout=900, headers=None):
-        assert timeout == 900
+    def fake_get(url, *, timeout, headers=None):
+        assert timeout == 10
         calls.append((url, timeout))
         downloaded["url"] = url
         resp = requests.Response()
@@ -273,14 +273,14 @@ def test_download_translated_file(monkeypatch, tmp_path):
     assert downloaded["url"] == "http://example/translated.srt"
     assert result == b"translated"
     assert calls == [
-        ("http://example/languages", 900),
-        ("http://example/translated.srt", 900),
+        ("http://example/languages", 10),
+        ("http://example/translated.srt", 10),
     ]
 
 
 def test_unsupported_source_language(monkeypatch):
-    def fake_get(self, url, *, timeout=900):
-        assert timeout == 900
+    def fake_get(self, url, *, timeout):
+        assert timeout == 10
         resp = requests.Response()
         resp.status_code = 200
         resp._content = b'[{"code": "en", "targets": ["en", "nl"]}]'
@@ -296,8 +296,8 @@ def test_unsupported_target_language(monkeypatch, tmp_path):
     tmp_file = tmp_path / "sample.en.srt"
     tmp_file.write_text("1\n00:00:00,000 --> 00:00:02,000\nHello\n")
 
-    def fake_get(self, url, *, timeout=900):
-        assert timeout == 900
+    def fake_get(self, url, *, timeout):
+        assert timeout == 10
         resp = requests.Response()
         resp.status_code = 200
         resp._content = b'[{"code": "en", "targets": ["en"]}]'

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -53,6 +53,22 @@ def test_translate_file_thread_safety(monkeypatch, tmp_path):
     asyncio.run(api.close())
 
 
+def test_is_available_uses_http_timeout(monkeypatch):
+    client = LibreTranslateClient("http://only", "en")
+
+    class DummyResp:
+        status_code = 200
+
+    def fake_head(self, url, *, timeout):
+        assert timeout == 10
+        return DummyResp()
+
+    monkeypatch.setattr(requests.Session, "head", fake_head)
+
+    assert client.is_available() is True
+    asyncio.run(client.api.close())
+
+
 def _prepared_client():
     client = LibreTranslateClient("http://example", "en")
     client.languages = {"en": {"nl"}}


### PR DESCRIPTION
## Summary
- add `http_timeout` and `translation_timeout` options
- apply timeouts across HTTP interactions
- document and test new timeout behavior

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a4e9bdee58832d854f188a8998780f