### PR TITLE
fix: increase default HTTP timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ docker run -d --name babelarr \
 | `DEBOUNCE_SECONDS` | `0.1` | Wait time to ensure files have finished writing before enqueueing. |
 | `SCAN_INTERVAL_MINUTES` | `60` | Minutes between full directory scans. |
 | `AVAILABILITY_CHECK_INTERVAL` | `30` | Seconds between checks for LibreTranslate availability. |
-| `HTTP_TIMEOUT` | `10` | Timeout in seconds for non-translation HTTP requests. |
+| `HTTP_TIMEOUT` | `30` | Timeout in seconds for non-translation HTTP requests. |
 | `TRANSLATION_TIMEOUT` | `900` | Timeout in seconds for translation requests. |
 | `QUEUE_DB` | `/config/queue.db` | Path to the SQLite queue database. |
 

--- a/babelarr/config.py
+++ b/babelarr/config.py
@@ -44,7 +44,7 @@ class Config:
     availability_check_interval: float = 30.0
     debounce: float = 0.1
     scan_interval_minutes: int = 60
-    http_timeout: float = 10.0
+    http_timeout: float = 30.0
     translation_timeout: float = 900.0
     persistent_sessions: bool = False
 
@@ -172,7 +172,7 @@ class Config:
             ),
             "DEBOUNCE_SECONDS": lambda v: cls._parse_float("DEBOUNCE_SECONDS", v, 0.1),
             "SCAN_INTERVAL_MINUTES": cls._parse_scan_interval,
-            "HTTP_TIMEOUT": lambda v: cls._parse_float("HTTP_TIMEOUT", v, 10.0),
+            "HTTP_TIMEOUT": lambda v: cls._parse_float("HTTP_TIMEOUT", v, 30.0),
             "TRANSLATION_TIMEOUT": lambda v: cls._parse_float(
                 "TRANSLATION_TIMEOUT", v, 900.0
             ),

--- a/babelarr/jellyfin_api.py
+++ b/babelarr/jellyfin_api.py
@@ -8,7 +8,7 @@ import requests
 class JellyfinClient:
     """Minimal client for Jellyfin refresh API."""
 
-    def __init__(self, base_url: str, token: str, timeout: float = 10.0) -> None:
+    def __init__(self, base_url: str, token: str, timeout: float = 30.0) -> None:
         self.base_url = base_url.rstrip("/")
         self.token = token
         self.timeout = timeout

--- a/babelarr/libretranslate_api.py
+++ b/babelarr/libretranslate_api.py
@@ -21,7 +21,7 @@ class LibreTranslateAPI:
         self,
         base_url: str,
         *,
-        http_timeout: float = 10.0,
+        http_timeout: float = 30.0,
         translation_timeout: float = 900.0,
         persistent_session: bool = False,
     ) -> None:

--- a/babelarr/translator.py
+++ b/babelarr/translator.py
@@ -51,7 +51,7 @@ class LibreTranslateClient:
         availability_check_interval: float = 30.0,
         api_key: str | None = None,
         persistent_session: bool = False,
-        http_timeout: float = 10.0,
+        http_timeout: float = 30.0,
         translation_timeout: float = 900.0,
     ) -> None:
         self.src_lang = src_lang

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -214,7 +214,7 @@ def test_validate_environment_logs_environment_ready(tmp_path, monkeypatch, capl
         status_code = 200
 
     def fake_head(url, *, timeout):
-        assert timeout == 10
+        assert timeout == 30
         return DummyResp()
 
     monkeypatch.setattr(cli.requests, "head", fake_head)

--- a/tests/test_jellyfin_api.py
+++ b/tests/test_jellyfin_api.py
@@ -25,4 +25,4 @@ def test_refresh_path(monkeypatch):
     assert calls["url"] == "http://jf/Library/Media/Updated"
     assert calls["json"] == {"Updates": [{"Path": "/data/file.srt"}]}
     assert calls["headers"] == {"X-Emby-Token": "tok"}
-    assert calls["timeout"] == 10
+    assert calls["timeout"] == 30

--- a/tests/test_libretranslate_api.py
+++ b/tests/test_libretranslate_api.py
@@ -9,7 +9,7 @@ from babelarr.libretranslate_api import LibreTranslateAPI
 def test_fetch_languages(monkeypatch):
     def fake_get(self, url, *, timeout):
         assert url == "http://only/languages"
-        assert timeout == 10
+        assert timeout == 30
         resp = requests.Response()
         resp.status_code = 200
         resp._content = b"[]"
@@ -27,7 +27,7 @@ def test_fetch_languages(monkeypatch):
 
 def test_fetch_languages_error(monkeypatch):
     def fake_get(self, url, *, timeout):
-        assert timeout == 10
+        assert timeout == 30
         raise requests.ConnectionError("boom")
 
     monkeypatch.setattr(requests.Session, "get", fake_get)
@@ -95,7 +95,7 @@ def test_download_uses_connection_close(monkeypatch):
     calls: list[dict | None] = []
 
     def fake_get(url, *, timeout, headers=None):
-        assert timeout == 10
+        assert timeout == 30
         calls.append(headers)
         resp = requests.Response()
         resp.status_code = 200

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -80,7 +80,7 @@ def test_retry_success(monkeypatch, tmp_path, caplog):
         return resp
 
     def fake_get(self, url, *, timeout):
-        assert timeout == 10
+        assert timeout == 30
         resp = requests.Response()
         resp.status_code = 200
         resp._content = (
@@ -117,7 +117,7 @@ def test_retry_exhaustion(monkeypatch, tmp_path, caplog):
         raise requests.ConnectionError("boom")
 
     def fake_get(self, url, *, timeout):
-        assert timeout == 10
+        assert timeout == 30
         resp = requests.Response()
         resp.status_code = 200
         resp._content = (
@@ -157,7 +157,7 @@ def test_api_key_included(monkeypatch, tmp_path):
         return resp
 
     def fake_get(self, url, *, timeout):
-        assert timeout == 10
+        assert timeout == 30
         resp = requests.Response()
         resp.status_code = 200
         resp._content = (
@@ -199,7 +199,7 @@ def test_src_lang_included(monkeypatch, tmp_path):
         return resp
 
     def fake_get(self, url, *, timeout):
-        assert timeout == 10
+        assert timeout == 30
         resp = requests.Response()
         resp.status_code = 200
         resp._content = (
@@ -240,7 +240,7 @@ def test_download_translated_file(monkeypatch, tmp_path):
     calls: list[tuple[str, int]] = []
 
     def fake_get_session(self, url, *, timeout):
-        assert timeout == 10
+        assert timeout == 30
         calls.append((url, timeout))
         resp = requests.Response()
         resp.status_code = 200
@@ -251,7 +251,7 @@ def test_download_translated_file(monkeypatch, tmp_path):
         return resp
 
     def fake_get(url, *, timeout, headers=None):
-        assert timeout == 10
+        assert timeout == 30
         calls.append((url, timeout))
         downloaded["url"] = url
         resp = requests.Response()
@@ -273,14 +273,14 @@ def test_download_translated_file(monkeypatch, tmp_path):
     assert downloaded["url"] == "http://example/translated.srt"
     assert result == b"translated"
     assert calls == [
-        ("http://example/languages", 10),
-        ("http://example/translated.srt", 10),
+        ("http://example/languages", 30),
+        ("http://example/translated.srt", 30),
     ]
 
 
 def test_unsupported_source_language(monkeypatch):
     def fake_get(self, url, *, timeout):
-        assert timeout == 10
+        assert timeout == 30
         resp = requests.Response()
         resp.status_code = 200
         resp._content = b'[{"code": "en", "targets": ["en", "nl"]}]'
@@ -297,7 +297,7 @@ def test_unsupported_target_language(monkeypatch, tmp_path):
     tmp_file.write_text("1\n00:00:00,000 --> 00:00:02,000\nHello\n")
 
     def fake_get(self, url, *, timeout):
-        assert timeout == 10
+        assert timeout == 30
         resp = requests.Response()
         resp.status_code = 200
         resp._content = b'[{"code": "en", "targets": ["en"]}]'

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -60,7 +60,7 @@ def test_is_available_uses_http_timeout(monkeypatch):
         status_code = 200
 
     def fake_head(self, url, *, timeout):
-        assert timeout == 10
+        assert timeout == 30
         return DummyResp()
 
     monkeypatch.setattr(requests.Session, "head", fake_head)


### PR DESCRIPTION
## Summary
- bump default HTTP timeout for LibreTranslate interactions to 30s
- document new timeout and align tests

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a4ece4e72c832d856768f446599795