### PR TITLE
fix: log translation outcome before jellyfin refresh

### DIFF
--- a/babelarr/worker.py
+++ b/babelarr/worker.py
@@ -138,14 +138,14 @@ def worker(app: Application) -> None:
                 )
             else:
                 app.db.remove(path, lang)
-                if app.jellyfin:
-                    app.translation_done(path, lang)
                 tlog.info(
                     "translation outcome=%s duration=%.2fs queue=%d",
                     outcome,
                     elapsed,
                     app.db.count(),
                 )
+                if app.jellyfin:
+                    app.translation_done(path, lang)
             app.tasks.task_done()
             tlog.debug(
                 "worker_finish name=%s duration=%.2fs",


### PR DESCRIPTION
## Summary
- log translation completion before triggering Jellyfin refresh
- test logging order of worker and Jellyfin refresh

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a4fcbc7074832d8b3738dd5557b448