### PR TITLE
feat: log show directory in Jellyfin refresh

### DIFF
--- a/babelarr/app.py
+++ b/babelarr/app.py
@@ -101,7 +101,9 @@ class Application:
         if self.jellyfin:
             try:
                 self.jellyfin.refresh_path(folder)
-                TranslationLogger(folder, lang).info("trigger_jellyfin_scan")
+                TranslationLogger(folder, lang).info(
+                    "jellyfin_refresh show=%s", folder.parent.name
+                )
             except Exception as exc:  # noqa: BLE001
                 TranslationLogger(folder, lang).error(
                     "jellyfin_refresh_failed error=%s", exc

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -291,7 +291,9 @@ def test_translation_done_logs_jellyfin_refresh(tmp_path, app, caplog):
         instance.translation_done(src, "nl")
 
     assert triggered == [tmp_path]
-    assert "trigger_jellyfin_scan" in caplog.text
+    assert "jellyfin_refresh" in caplog.text
+    assert f"path={tmp_path.name}" in caplog.text
+    assert f"show={tmp_path.parent.name}" in caplog.text
 
 
 def test_translation_done_refreshes_once_per_folder(tmp_path, app, caplog):
@@ -317,4 +319,5 @@ def test_translation_done_refreshes_once_per_folder(tmp_path, app, caplog):
         instance.translation_done(second, "nl")
 
     assert triggered == [tmp_path]
-    assert caplog.text.count("trigger_jellyfin_scan") == 1
+    assert caplog.text.count("jellyfin_refresh") == 1
+    assert f"show={tmp_path.parent.name}" in caplog.text


### PR DESCRIPTION
## Summary
- log `jellyfin_refresh` events with show directory info
- update tests for new Jellyfin refresh logging

## Testing
- `make setup`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a4fcbe8910832daa35f23b6a031aa3