### PR TITLE
feat: expire idle workers

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 import threading
 from concurrent.futures import ThreadPoolExecutor
@@ -222,7 +223,7 @@ def test_configurable_scan_interval(monkeypatch, config, app):
     assert called["func"].__func__ is instance.request_scan.__func__
 
 
-def test_workers_spawn_and_exit(tmp_path, app, caplog):
+def test_workers_spawn_and_exit(tmp_path, app, caplog, monkeypatch):
     src = tmp_path / "video.en.srt"
     src.write_text("hello")
 
@@ -240,6 +241,13 @@ def test_workers_spawn_and_exit(tmp_path, app, caplog):
             return None
 
     translator = BlockingTranslator()
+    import babelarr.app as app_module
+
+    monkeypatch.setattr(
+        app_module,
+        "worker_loop",
+        functools.partial(worker_module.worker, idle_timeout=0.1),
+    )
     instance = app(translator=translator)
     assert instance._active_workers == 0
 


### PR DESCRIPTION
## Summary
- shut down idle workers after configurable timeout (30m default)
- add regression tests for worker exit
- adjust worker lifecycle tests to use patched timeout

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68a587bfede4832d85bc8de5c04c9fb1