### PR TITLE
fix: remove cli log prefixes

### DIFF
--- a/babelarr/cli.py
+++ b/babelarr/cli.py
@@ -43,7 +43,7 @@ def validate_environment(config: Config) -> None:
 
     config.root_dirs = valid_dirs
     logger.info(
-        "cli: environment_ready dirs=%s",
+        "environment_ready dirs=%s",
         [Path(d).name for d in valid_dirs],
     )
 
@@ -83,7 +83,7 @@ def filter_target_languages(config: Config, translator: LibreTranslateClient) ->
             lang for lang in config.target_langs if lang in supported
         ]
 
-    logger.info("cli: target_langs langs=%s", ", ".join(config.target_langs))
+    logger.info("target_langs langs=%s", ", ".join(config.target_langs))
     if not config.target_langs:
         logger.error("no_supported_targets")
         raise SystemExit("No supported target languages configured")
@@ -113,7 +113,7 @@ def main(argv: list[str] | None = None) -> None:
     )
     logging.getLogger("watchdog").setLevel(logging.INFO)
     logging.getLogger("urllib3").setLevel(logging.WARNING)
-    logger.info("cli: start log_level=%s log_file=%s", log_level, log_file)
+    logger.info("start log_level=%s log_file=%s", log_level, log_file)
 
     if args.command == "queue":
         config = Config.from_env()
@@ -129,7 +129,7 @@ def main(argv: list[str] | None = None) -> None:
     config = Config.from_env()
     validate_environment(config)
     logger.info(
-        "cli: config_loaded api_url=%s targets=%s",
+        "config_loaded api_url=%s targets=%s",
         config.api_url,
         config.target_langs,
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -147,8 +147,8 @@ def test_main_logs_start_and_config_loaded(monkeypatch, caplog):
     with caplog.at_level(logging.INFO):
         cli.main([])
 
-    assert "cli: start log_level=INFO log_file=None" in caplog.text
-    assert "cli: config_loaded api_url=http://example targets=['nl']" in caplog.text
+    assert "start log_level=INFO log_file=None" in caplog.text
+    assert "config_loaded api_url=http://example targets=['nl']" in caplog.text
 
 
 def test_queue_outputs_count_and_paths(tmp_path, monkeypatch, capsys):
@@ -221,7 +221,7 @@ def test_validate_environment_logs_environment_ready(tmp_path, monkeypatch, capl
 
     with caplog.at_level(logging.INFO):
         cli.validate_environment(config)
-        assert "cli: environment_ready" in caplog.text
+        assert "environment_ready" in caplog.text
 
 
 def test_filter_target_languages_removes_unsupported(caplog):
@@ -248,7 +248,7 @@ def test_filter_target_languages_removes_unsupported(caplog):
         cli.filter_target_languages(config, translator)
         assert config.target_langs == ["nl"]
         assert "unsupported_targets" in caplog.text
-        assert "cli: target_langs langs=nl" in caplog.text
+        assert "target_langs langs=nl" in caplog.text
 
 
 def test_filter_target_languages_exits_when_none_supported():


### PR DESCRIPTION
## Summary
- drop redundant `cli:` prefix from logging messages and rely on logger name for context
- update CLI tests to match revised log messages

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a593105b54832da993fb89b19d3772