### PR TITLE
fix: simplify translator log messages

### DIFF
--- a/babelarr/translator.py
+++ b/babelarr/translator.py
@@ -88,7 +88,7 @@ class LibreTranslateClient:
                 except requests.RequestException as exc:
                     logger.warning("fetch_languages_failed error=%s", exc)
                 else:
-                    logger.info("translator: service_available")
+                    logger.info("service_available")
                     return
             logger.warning(
                 "service_unreachable retry=%s",
@@ -108,7 +108,7 @@ class LibreTranslateClient:
             raise ValueError(f"Unsupported source language: {self.src_lang}")
         self.supported_targets = self.languages[self.src_lang]
         logger.info(
-            "translator: languages_loaded count=%d",
+            "languages_loaded count=%d",
             len(self.supported_targets),
         )
 

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -176,7 +176,7 @@ def test_ensure_languages_logs_count(monkeypatch, caplog):
     )
     with caplog.at_level(logging.INFO):
         client.ensure_languages()
-    assert "translator: languages_loaded count=2" in caplog.text
+    assert "languages_loaded count=2" in caplog.text
 
 
 def test_wait_until_available_logs_service_available(monkeypatch, caplog):
@@ -187,4 +187,4 @@ def test_wait_until_available_logs_service_available(monkeypatch, caplog):
     monkeypatch.setattr(client, "ensure_languages", lambda: None)
     with caplog.at_level(logging.INFO):
         client.wait_until_available()
-    assert "translator: service_available" in caplog.text
+    assert "service_available" in caplog.text


### PR DESCRIPTION
## Summary
- drop redundant `translator:` prefix from log messages
- adjust translator tests for new log text

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a59311b644832db17f913c207951b7