### PR TITLE
fix: omit lang from Jellyfin refresh logs

### DIFF
--- a/babelarr/app.py
+++ b/babelarr/app.py
@@ -101,13 +101,11 @@ class Application:
         if self.jellyfin:
             try:
                 self.jellyfin.refresh_path(folder)
-                TranslationLogger(folder, lang).info(
+                TranslationLogger(folder).info(
                     "jellyfin_refresh show=%s", folder.parent.name
                 )
             except Exception as exc:  # noqa: BLE001
-                TranslationLogger(folder, lang).error(
-                    "jellyfin_refresh_failed error=%s", exc
-                )
+                TranslationLogger(folder).error("jellyfin_refresh_failed error=%s", exc)
 
     def enqueue(self, path: Path, *, priority: int = 0) -> None:
         """Queue *path* for translation with the given *priority*.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -302,6 +302,7 @@ def test_translation_done_logs_jellyfin_refresh(tmp_path, app, caplog):
     assert "jellyfin_refresh" in caplog.text
     assert f"path={tmp_path.name}" in caplog.text
     assert f"show={tmp_path.parent.name}" in caplog.text
+    assert "lang=" not in caplog.text
 
 
 def test_translation_done_refreshes_once_per_folder(tmp_path, app, caplog):
@@ -329,3 +330,4 @@ def test_translation_done_refreshes_once_per_folder(tmp_path, app, caplog):
     assert triggered == [tmp_path]
     assert caplog.text.count("jellyfin_refresh") == 1
     assert f"show={tmp_path.parent.name}" in caplog.text
+    assert "lang=" not in caplog.text


### PR DESCRIPTION
## Summary
- avoid including lang in Jellyfin refresh logs
- test for absence of lang in Jellyfin refresh logs

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a5a29f3dd0832da696521f1ce45734