### PR TITLE
fix: close fetch_languages connections

### DIFF
--- a/babelarr/libretranslate_api.py
+++ b/babelarr/libretranslate_api.py
@@ -48,7 +48,11 @@ class LibreTranslateAPI:
         """Return the languages supported by the server."""
 
         url = self.base_url + "/languages"
-        resp = self.session.get(url, timeout=self.http_timeout)
+        if self.persistent_session:
+            resp = self.session.get(url, timeout=self.http_timeout)
+        else:
+            headers = {"Connection": "close"}
+            resp = requests.get(url, timeout=self.http_timeout, headers=headers)
         resp.raise_for_status()
         return resp.json()
 


### PR DESCRIPTION
## Summary
- use thread-local session for fetch_languages when persistent
- close connections for non-persistent fetch_languages requests
- expand tests for language fetching and update mocks

## Testing
- `make setup`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a5b5b569fc832da11ba50059f45a09