### PR TITLE
refactor: reuse queue length in worker logs

### DIFF
--- a/babelarr/worker.py
+++ b/babelarr/worker.py
@@ -139,18 +139,21 @@ def worker(app: Application, idle_timeout: float = 30 * 60) -> None:
             if requeue:
                 app.tasks.put((task.priority, app._task_counter, task))
                 app._task_counter += 1
+            else:
+                app.db.remove(path, lang)
+            queue_len = app.db.count()
+            if requeue:
                 tlog.info(
                     "worker_requeue name=%s queue=%d",
                     name,
-                    app.db.count(),
+                    queue_len,
                 )
             else:
-                app.db.remove(path, lang)
                 tlog.info(
                     "translation outcome=%s duration=%.2fs queue=%d",
                     outcome,
                     elapsed,
-                    app.db.count(),
+                    queue_len,
                 )
                 if app.jellyfin:
                     app.translation_done(path, lang)


### PR DESCRIPTION
## Summary
- compute queue length once per task and reuse when logging worker status

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a5b5cbc874832d96e67105e21f068e