### PR TITLE
style: start config log messages with action verbs

### DIFF
--- a/babelarr/config.py
+++ b/babelarr/config.py
@@ -56,23 +56,23 @@ class Config:
         for lang in raw_langs:
             cleaned = lang.strip()
             if not cleaned:
-                logger.warning("Empty language code in TARGET_LANGS; ignoring")
+                logger.warning("ignore empty language code in TARGET_LANGS")
                 continue
             if not cleaned.isalpha():
                 logger.warning(
-                    "Invalid language code '%s' in TARGET_LANGS; ignoring", cleaned
+                    "ignore invalid language code '%s' in TARGET_LANGS", cleaned
                 )
                 continue
             normalized = cleaned.lower()
             if normalized in seen:
                 logger.debug(
-                    "Duplicate language code '%s' in TARGET_LANGS; ignoring", cleaned
+                    "ignore duplicate language code '%s' in TARGET_LANGS", cleaned
                 )
                 continue
             target_langs.append(normalized)
             seen.add(normalized)
         if not target_langs:
-            logger.error("No valid languages found in TARGET_LANGS")
+            logger.error("found no valid languages in TARGET_LANGS")
             raise ValueError(
                 "TARGET_LANGS must contain at least one valid language code",
             )
@@ -87,15 +87,15 @@ class Config:
             requested = int(raw_workers)
         except ValueError:
             logger.warning(
-                "Invalid WORKERS '%s'; defaulting to %s", raw_workers, default_workers
+                "use default %s for invalid WORKERS '%s'", default_workers, raw_workers
             )
             requested = default_workers
         workers = min(requested, MAX_WORKERS)
         if requested > MAX_WORKERS:
             logger.warning(
-                "Requested %s workers, capping at %s to prevent instability",
-                requested,
+                "cap workers at %s to prevent instability (requested %s)",
                 MAX_WORKERS,
+                requested,
             )
         return workers
 
@@ -107,9 +107,9 @@ class Config:
             return int(raw_scan)
         except ValueError:
             logger.warning(
-                "Invalid SCAN_INTERVAL_MINUTES '%s'; defaulting to %s",
-                raw_scan,
+                "use default %s for invalid SCAN_INTERVAL_MINUTES '%s'",
                 default_scan_interval,
+                raw_scan,
             )
             return default_scan_interval
 
@@ -119,7 +119,12 @@ class Config:
         try:
             return int(raw_val)
         except ValueError:
-            logger.warning("Invalid %s '%s'; defaulting to %s", name, raw_val, default)
+            logger.warning(
+                "use default %s for invalid %s '%s'",
+                default,
+                name,
+                raw_val,
+            )
             return default
 
     @staticmethod
@@ -128,7 +133,12 @@ class Config:
         try:
             return float(raw_val)
         except ValueError:
-            logger.warning("Invalid %s '%s'; defaulting to %s", name, raw_val, default)
+            logger.warning(
+                "use default %s for invalid %s '%s'",
+                default,
+                name,
+                raw_val,
+            )
             return default
 
     @staticmethod
@@ -140,7 +150,12 @@ class Config:
                 return True
             if lowered in {"0", "false", "no", "off"}:
                 return False
-        logger.warning("Invalid %s '%s'; defaulting to %s", name, raw_val, default)
+        logger.warning(
+            "use default %s for invalid %s '%s'",
+            default,
+            name,
+            raw_val,
+        )
         return default
 
     @classmethod
@@ -149,7 +164,7 @@ class Config:
 
         src_lang = os.environ.get("SRC_LANG", "en").strip().lower()
         if not src_lang.isalpha():
-            logger.warning("Invalid SRC_LANG '%s'; defaulting to 'en'", src_lang)
+            logger.warning("use default 'en' for invalid SRC_LANG '%s'", src_lang)
             src_lang = "en"
         src_ext = f".{src_lang}.srt"
         api_url = os.environ.get("LIBRETRANSLATE_URL", "http://libretranslate:5000")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,8 +15,8 @@ def test_parse_target_languages_filters_and_normalizes(caplog):
     with caplog.at_level(logging.WARNING, logger="babelarr"):
         langs = Config._parse_target_languages(raw)
     assert langs == ["nl", "en"]
-    assert "Empty language code" in caplog.text
-    assert "Invalid language code 'xx1'" in caplog.text
+    assert "ignore empty language code" in caplog.text
+    assert "ignore invalid language code 'xx1'" in caplog.text
 
 
 def test_parse_target_languages_empty_raises():
@@ -28,14 +28,14 @@ def test_parse_workers_caps_and_defaults(caplog):
     with caplog.at_level(logging.WARNING, logger="babelarr"):
         workers = Config._parse_workers("20")
     assert workers == 10
-    assert "capping" in caplog.text
+    assert "cap workers" in caplog.text
 
 
 def test_parse_scan_interval_invalid(caplog):
     with caplog.at_level(logging.WARNING, logger="babelarr"):
         interval = Config._parse_scan_interval("bad")
     assert interval == 60
-    assert "Invalid SCAN_INTERVAL_MINUTES" in caplog.text
+    assert "invalid SCAN_INTERVAL_MINUTES" in caplog.text
 
 
 def test_from_env_rejects_empty_target_langs(monkeypatch):
@@ -49,7 +49,7 @@ def test_invalid_workers_falls_back_to_default(monkeypatch, caplog):
     with caplog.at_level(logging.WARNING, logger="babelarr"):
         cfg = Config.from_env()
     assert cfg.workers == 1
-    assert "Invalid WORKERS" in caplog.text
+    assert "invalid WORKERS" in caplog.text
 
 
 def test_invalid_retry_count_falls_back_to_default(monkeypatch, caplog):
@@ -57,7 +57,7 @@ def test_invalid_retry_count_falls_back_to_default(monkeypatch, caplog):
     with caplog.at_level(logging.WARNING, logger="babelarr"):
         cfg = Config.from_env()
     assert cfg.retry_count == 3
-    assert "Invalid RETRY_COUNT" in caplog.text
+    assert "invalid RETRY_COUNT" in caplog.text
 
 
 def test_invalid_backoff_delay_falls_back_to_default(monkeypatch, caplog):
@@ -65,7 +65,7 @@ def test_invalid_backoff_delay_falls_back_to_default(monkeypatch, caplog):
     with caplog.at_level(logging.WARNING, logger="babelarr"):
         cfg = Config.from_env()
     assert cfg.backoff_delay == 1.0
-    assert "Invalid BACKOFF_DELAY" in caplog.text
+    assert "invalid BACKOFF_DELAY" in caplog.text
 
 
 def test_invalid_debounce_falls_back_to_default(monkeypatch, caplog):
@@ -73,7 +73,7 @@ def test_invalid_debounce_falls_back_to_default(monkeypatch, caplog):
     with caplog.at_level(logging.WARNING, logger="babelarr"):
         cfg = Config.from_env()
     assert cfg.debounce == 0.1
-    assert "Invalid DEBOUNCE_SECONDS" in caplog.text
+    assert "invalid DEBOUNCE_SECONDS" in caplog.text
 
 
 def test_invalid_scan_interval_falls_back_to_default(monkeypatch, caplog):
@@ -81,7 +81,7 @@ def test_invalid_scan_interval_falls_back_to_default(monkeypatch, caplog):
     with caplog.at_level(logging.WARNING, logger="babelarr"):
         cfg = Config.from_env()
     assert cfg.scan_interval_minutes == 60
-    assert "Invalid SCAN_INTERVAL_MINUTES" in caplog.text
+    assert "invalid SCAN_INTERVAL_MINUTES" in caplog.text
 
 
 def test_persistent_sessions_flag(monkeypatch):


### PR DESCRIPTION
## Summary
- reword configuration parsing logs to start with concise action verbs
- align config tests with updated log phrasing

## Testing
- `make setup`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a5c0faf56c832d977448664ba841d7