### PR TITLE
refactor: make LibreTranslateAPI.close synchronous

### DIFF
--- a/babelarr/libretranslate_api.py
+++ b/babelarr/libretranslate_api.py
@@ -93,8 +93,8 @@ class LibreTranslateAPI:
         headers = {"Connection": "close"}
         return requests.get(url, timeout=self.http_timeout, headers=headers)
 
-    async def close(self) -> None:
-        """Asynchronously close the thread-local session for this thread."""
+    def close(self) -> None:
+        """Close the thread-local session for this thread."""
 
         session = getattr(self._local, "session", None)
         if session:

--- a/babelarr/translator.py
+++ b/babelarr/translator.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import time
 from pathlib import Path
@@ -199,4 +198,4 @@ class LibreTranslateClient:
                 time.sleep(delay)
 
     def close(self) -> None:
-        asyncio.run(self.api.close())
+        self.api.close()

--- a/tests/test_libretranslate_api.py
+++ b/tests/test_libretranslate_api.py
@@ -1,5 +1,3 @@
-import asyncio
-
 import pytest
 import requests
 
@@ -26,7 +24,7 @@ def test_fetch_languages(monkeypatch):
     assert languages == []
     assert calls == [{"Connection": "close"}]
 
-    asyncio.run(api.close())
+    api.close()
 
 
 def test_fetch_languages_error(monkeypatch):
@@ -41,7 +39,7 @@ def test_fetch_languages_error(monkeypatch):
     with pytest.raises(requests.ConnectionError):
         api.fetch_languages()
 
-    asyncio.run(api.close())
+    api.close()
 
 
 def test_fetch_languages_persistent_session(monkeypatch):
@@ -64,7 +62,7 @@ def test_fetch_languages_persistent_session(monkeypatch):
 
     assert len(set(sessions)) == 1
 
-    asyncio.run(api.close())
+    api.close()
 
 
 def test_translate_file_error(monkeypatch, tmp_path):
@@ -82,7 +80,7 @@ def test_translate_file_error(monkeypatch, tmp_path):
     with pytest.raises(requests.ConnectionError):
         api.translate_file(tmp_file, "en", "nl")
 
-    asyncio.run(api.close())
+    api.close()
 
 
 def test_translate_file(monkeypatch, tmp_path):
@@ -115,7 +113,7 @@ def test_translate_file(monkeypatch, tmp_path):
 
     assert headers_seen == [{"Connection": "close"}, {"Connection": "close"}]
 
-    asyncio.run(api.close())
+    api.close()
 
 
 def test_download_uses_connection_close(monkeypatch):
@@ -136,7 +134,7 @@ def test_download_uses_connection_close(monkeypatch):
     assert resp.content == b"data"
     assert calls == [{"Connection": "close"}]
 
-    asyncio.run(api.close())
+    api.close()
 
 
 def test_translate_file_persistent_session(monkeypatch, tmp_path):
@@ -161,4 +159,4 @@ def test_translate_file_persistent_session(monkeypatch, tmp_path):
 
     assert len(set(sessions)) == 1
 
-    asyncio.run(api.close())
+    api.close()

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import threading
 
@@ -50,7 +49,7 @@ def test_translate_file_thread_safety(monkeypatch, tmp_path):
     assert len(calls) == 5
     assert all(h == {"Connection": "close"} for h in calls.values())
 
-    asyncio.run(api.close())
+    api.close()
 
 
 def test_is_available_uses_http_timeout(monkeypatch):
@@ -66,7 +65,7 @@ def test_is_available_uses_http_timeout(monkeypatch):
     monkeypatch.setattr(requests.Session, "head", fake_head)
 
     assert client.is_available() is True
-    asyncio.run(client.api.close())
+    client.api.close()
 
 
 def _prepared_client():


### PR DESCRIPTION
## Summary
- make `LibreTranslateAPI.close` synchronous and update docstring
- call API `close` directly from `LibreTranslateClient`
- update tests for synchronous `close`

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a5c1074588832da07f66ee5fe7ab00