### PR TITLE
feat: make subtitle stabilization timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ docker run -d --name babelarr \
 | `RETRY_COUNT` | `3` | Translation retry attempts. |
 | `BACKOFF_DELAY` | `1` | Initial delay between retries in seconds. |
 | `DEBOUNCE_SECONDS` | `0.1` | Wait time to ensure files have finished writing before enqueueing. |
+| `STABILIZE_TIMEOUT` | `30` | Max seconds to wait for a subtitle file to stop growing before enqueueing. |
 | `SCAN_INTERVAL_MINUTES` | `60` | Minutes between full directory scans. |
 | `AVAILABILITY_CHECK_INTERVAL` | `30` | Seconds between checks for LibreTranslate availability. |
 | `HTTP_TIMEOUT` | `30` | Timeout in seconds for non-translation HTTP requests. |

--- a/babelarr/config.py
+++ b/babelarr/config.py
@@ -26,6 +26,7 @@ class Config:
         retry_count: Translation retry attempts.
         backoff_delay: Initial backoff delay between retries.
         debounce: Seconds to wait for file changes to settle before enqueueing.
+        stabilize_timeout: Max seconds to wait for file size to stabilize.
         scan_interval_minutes: Interval between periodic full scans.
     """
 
@@ -43,6 +44,7 @@ class Config:
     backoff_delay: float = 1.0
     availability_check_interval: float = 30.0
     debounce: float = 0.1
+    stabilize_timeout: float = 30.0
     scan_interval_minutes: int = 60
     http_timeout: float = 30.0
     translation_timeout: float = 900.0
@@ -186,6 +188,9 @@ class Config:
                 "AVAILABILITY_CHECK_INTERVAL", v, 30.0
             ),
             "DEBOUNCE_SECONDS": lambda v: cls._parse_float("DEBOUNCE_SECONDS", v, 0.1),
+            "STABILIZE_TIMEOUT": lambda v: cls._parse_float(
+                "STABILIZE_TIMEOUT", v, 30.0
+            ),
             "SCAN_INTERVAL_MINUTES": cls._parse_scan_interval,
             "HTTP_TIMEOUT": lambda v: cls._parse_float("HTTP_TIMEOUT", v, 30.0),
             "TRANSLATION_TIMEOUT": lambda v: cls._parse_float(
@@ -206,6 +211,7 @@ class Config:
         backoff_delay = parsed["BACKOFF_DELAY"]
         availability_check_interval = parsed["AVAILABILITY_CHECK_INTERVAL"]
         debounce = parsed["DEBOUNCE_SECONDS"]
+        stabilize_timeout = parsed["STABILIZE_TIMEOUT"]
         scan_interval_minutes = parsed["SCAN_INTERVAL_MINUTES"]
         http_timeout = parsed["HTTP_TIMEOUT"]
         translation_timeout = parsed["TRANSLATION_TIMEOUT"]
@@ -215,7 +221,7 @@ class Config:
             "loaded config root_dirs=%s target_langs=%s src_lang=%s api_url=%s "
             "workers=%s queue_db=%s api_key_set=%s jellyfin_url=%s jellyfin_token_set=%s "
             "retry_count=%s backoff_delay=%s availability_check_interval=%s debounce=%s scan_interval_minutes=%s "
-            "persistent_sessions=%s http_timeout=%s translation_timeout=%s",
+            "stabilize_timeout=%s persistent_sessions=%s http_timeout=%s translation_timeout=%s",
             root_dirs,
             target_langs,
             src_lang,
@@ -229,6 +235,7 @@ class Config:
             backoff_delay,
             availability_check_interval,
             debounce,
+            stabilize_timeout,
             scan_interval_minutes,
             persistent_sessions,
             http_timeout,
@@ -250,6 +257,7 @@ class Config:
             backoff_delay=backoff_delay,
             availability_check_interval=availability_check_interval,
             debounce=debounce,
+            stabilize_timeout=stabilize_timeout,
             scan_interval_minutes=scan_interval_minutes,
             http_timeout=http_timeout,
             translation_timeout=translation_timeout,

--- a/babelarr/watch.py
+++ b/babelarr/watch.py
@@ -18,7 +18,7 @@ class SrtHandler(PatternMatchingEventHandler):
     def __init__(self, app: Application):
         self.app = app
         self._debounce = self.app.config.debounce
-        self._max_wait = 30
+        self._max_wait = self.app.config.stabilize_timeout
         self._recent: dict[Path, float] = {}
         self._last_prune = 0.0
         super().__init__(

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -22,6 +22,7 @@ def test_srt_handler_patterns(app):
     handler = SrtHandler(app_instance)
     assert handler.patterns == [f"*{app_instance.config.src_ext}"]
     assert handler.ignore_directories
+    assert handler._max_wait == app_instance.config.stabilize_timeout
 
 
 def test_srt_handler_enqueue(monkeypatch, tmp_path, app):
@@ -215,6 +216,7 @@ def test_srt_handler_timeout(monkeypatch, tmp_path, app, caplog):
     called = {}
     app_instance = app()
     app_instance.config.debounce = 0.01
+    app_instance.config.stabilize_timeout = 0.05
 
     def fake_enqueue(p):
         called["path"] = p
@@ -222,7 +224,6 @@ def test_srt_handler_timeout(monkeypatch, tmp_path, app, caplog):
     monkeypatch.setattr(app_instance, "enqueue", fake_enqueue)
 
     handler = SrtHandler(app_instance)
-    handler._max_wait = 0.05
 
     from itertools import count
     from types import SimpleNamespace


### PR DESCRIPTION
## Summary
- add `stabilize_timeout` to `Config` and parse from `STABILIZE_TIMEOUT`
- use configurable timeout for subtitle stabilization in `SrtHandler`
- document `STABILIZE_TIMEOUT` and update tests

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a636b28258832da7f5bf8c57e5cedc