### PR TITLE
feat: name worker threads from pool

### DIFF
--- a/babelarr/worker.py
+++ b/babelarr/worker.py
@@ -167,6 +167,8 @@ def worker(app: Application, idle_timeout: float = 30 * 60) -> None:
         with app._worker_lock:
             app._active_workers -= 1
             app._worker_threads.discard(threading.current_thread())
+            if name in getattr(app, "_worker_name_pool", set()):
+                app._available_worker_names.add(name)
             logger.info(
                 "worker_exit name=%s active=%d",
                 name,


### PR DESCRIPTION
## Summary
- name workers using a fixed pool of translator names
- recycle worker names when threads exit and warn when requested worker count exceeds pool
- cover worker name pool behaviour with tests
- expand worker name pool to support full worker limit

## Testing
- `make setup`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a805cddec4832db41c043b42949d29